### PR TITLE
Handle TypeError if no results from API

### DIFF
--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -72,7 +72,13 @@ export function getTripPatterns(
     const params = { query: getItinerariesProps, variables }
 
     return post(url, params, headers)
-        .then((response: Object) => response.data.trip.tripPatterns)
+        .then((response: Object) => {
+            try {
+                return response.data.trip.tripPatterns
+            } catch (e) {
+                return []
+            }
+        })
 }
 
 export function getStopPlaceDepartures(
@@ -125,5 +131,11 @@ export function getStopPlacesByPosition(
     const params = { query: getStopPlacesByBboxProps, variables }
 
     return post(url, params, headers)
-        .then(response => response.data.stopPlacesByBbox)
+        .then((response) => {
+            try {
+                return response.data.stopPlacesByBbox
+            } catch (e) {
+                return []
+            }
+        })
 }


### PR DESCRIPTION
Fixes #21 

`cleanDeep` transforms `{ data: { trip: { tripPatterns: [] } } }` to `{}`. Therefore accessing `data.trip` is not safe. This change will make sure an empty array is returned if result is empty, for getTripPatterns and getStopPlaceDepartures.