### PR TITLE
Fix and rename 'onForBoarding' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ If an array of strings is passed, the method will return an array of objects con
 ##### params (`Object`) [Optional]
 An optional object of parameters to pass to the query.
 
-| Key             | Type           | Default | Description |
-|:----------------|:---------------|:--------|:------------|
-| `startTime`     | ISO8601 string | Now     | DateTime for when to fetch estimated calls from. |
-| `range`         | `number`       | `86400` | The time range for departures to include in seconds. |
-| `departures`    | `number`       | `5`     | The number of departures to return for each stop place. |
-| `onForBoarding` | `boolean`      | `false` | Whether to include departures that do not accept boarding at given stop place. |
+| Key                  | Type           | Default | Description |
+|:---------------------|:---------------|:--------|:------------|
+| `startTime`          | ISO8601 string | Now     | DateTime for when to fetch estimated calls from. |
+| `range`              | `number`       | `86400` | The time range for departures to include in seconds. |
+| `departures`         | `number`       | `5`     | The number of departures to return for each stop place. |
+| `includeNonBoarding` | `boolean`      | `false` | Whether to include departures that do not accept boarding at given stop place. |
 
 
 ### getBikeRentalStation

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -284,14 +284,14 @@ declare module '@entur/sdk' {
             startTime?: string,
             range?: number,
             departures?: number,
-            onForBoarding?: boolean,
+            includeNonBoarding?: boolean,
         }): Promise<Array<$entur$sdk$EstimatedCall>>,
 
         getStopPlaceDepartures(stopPlaceIds: Array<string>, params?: {
             startTime?: string,
             range?: number,
             departures?: number,
-            onForBoarding?: boolean,
+            includeNonBoarding?: boolean,
         }): Promise<Array<{ id: string, departures: Array<$entur$sdk$EstimatedCall>}>>,
 
         getStopPlace(id: string): Promise<$entur$sdk$StopPlace>,

--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -19,7 +19,7 @@ import { convertPositionToBbox } from '../utils'
 
 
 type StopPlaceParams = {
-    onForBoarding?: boolean,
+    includeNonBoarding?: boolean,
     departures?: number,
     timeRange?: number,
 }
@@ -32,7 +32,7 @@ const DEFAULT_SEARCH_PARAMS = {
 }
 
 const DEFAULT_STOP_PLACE_PARAMS = {
-    onForBoarding: false,
+    includeNonBoarding: false,
     departures: 50,
     timeRange: 72000,
 }
@@ -78,8 +78,16 @@ export function getStopPlaceDepartures(
 ): Object {
     const { host, headers } = getJourneyPlannerHost(this.config)
     const {
-        timeRange, departures, onForBoarding,
+        timeRange, departures, onForBoarding, includeNonBoarding,
     } = { ...DEFAULT_STOP_PLACE_PARAMS, ...stopPlaceParams }
+
+    let omitNonBoarding = !includeNonBoarding
+
+    if (onForBoarding !== undefined) {
+        // eslint-disable-next-line no-console
+        console.info('Entur SDK: "onForBoarding" is deprecated, use "includeNonBoarding" instead.')
+        omitNonBoarding = !onForBoarding
+    }
 
     const url = `${host}/graphql`
 
@@ -90,7 +98,7 @@ export function getStopPlaceDepartures(
         start: new Date().toISOString(),
         range: timeRange,
         departures,
-        onForBoarding,
+        omitNonBoarding,
     }
 
     const params = { query: getStopPlaceDeparturesProps, variables }

--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -19,6 +19,7 @@ import { convertPositionToBbox } from '../utils'
 
 
 type StopPlaceParams = {
+    onForBoarding?: boolean, // deprecated
     includeNonBoarding?: boolean,
     departures?: number,
     timeRange?: number,

--- a/src/trip/query.js
+++ b/src/trip/query.js
@@ -123,10 +123,10 @@ export const getStopPlacesByBboxProps = `
 `
 
 export const getStopPlaceDeparturesProps = `
-    query StopPlaceDepartures($ids:[String]!,$start:DateTime!,$range:Int!,$departures:Int!,$onForBoarding:Boolean!) {
+    query StopPlaceDepartures($ids:[String]!,$start:DateTime!,$range:Int!,$departures:Int!,$omitNonBoarding:Boolean!) {
         stopPlaces(ids:$ids) {
           id
-          estimatedCalls(startTime:$start, timeRange:$range, numberOfDepartures:$departures, omitNonBoarding:$onForBoarding) { ...estimatedCallFields }
+          estimatedCalls(startTime:$start, timeRange:$range, numberOfDepartures:$departures, omitNonBoarding:$omitNonBoarding) { ...estimatedCallFields }
         }
     }
 


### PR DESCRIPTION
It was not negated before it was sent to the graphql query as 'omitNonBoarding', which means the opposite thing.

I also renamed it to 'includeNonBoarding' which makes more sense than 'onForBoarding' which sounds like a callback.
'onForBoarding' will still work, but a deprecation warning will be printed if the option is passed.