### PR TITLE
Add support for multiple searches that are rate limited

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,19 @@ The Entur SDK uses multiple endpoints for its services. Each endpoint can be ove
 ```javascript
 service.getTripPatterns(query);
 ```
-Returns: `Promise<Array<TripPattern>>`
+Returns: `Promise<Array<TripPattern>> | Promise<Array<TripPattern>>`
 
 Types: [TripPattern](flow-types/TripPattern.js)
 
-`getTripPatterns` is for searching for itineraries for a trip from some location to a destination at a given time. The method takes one argument `query`, which is an object with search parameters.
+`getTripPatterns` is for searching for itineraries for a trip from some location to a destination at a given time. The method takes one argument `query`, which is either an object with search parameters, or an array of those.
+
+When calling this with an array of search queries, the calls will be throttled to adhere with the API's rate limits. The order of the results will be the same as the order of the arguments sent in.
 
 #### Parameters
 
 ##### query (`Object`)
+A search query is an object on the following form. Mind that you can send an array of these to getTripPatterns to do multiple searches.
+
 | Key | Type | Default  | Description |
 |:----|:----|:----------|:------------|
 | `searchDate`            | `Date`             | | when to calculate patterns |

--- a/package-lock.json
+++ b/package-lock.json
@@ -961,7 +961,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -1116,7 +1116,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2681,7 +2681,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -2850,7 +2850,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -2911,7 +2911,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isplainobject": {
@@ -3199,7 +3199,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -3262,6 +3262,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
+    },
+    "promise-throttle": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/promise-throttle/-/promise-throttle-1.0.0.tgz",
+      "integrity": "sha512-pNX5XbCcuy97pZMqFfqCQTLe9oClKYoju2A3veEGvIEFDZKj1+vEbOWrO2IBN0OGhq5UpZ9RHXHnjFk+pm437g=="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -3394,7 +3399,7 @@
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@turf/destination": "^6.0.1",
     "clean-deep": "^3.0.2",
     "node-fetch": "^2.2.0",
+    "promise-throttle": "^1.0.0",
     "query-params": "0.0.1",
     "turf-linestring": "^1.0.2",
     "turf-point": "^2.0.1"

--- a/src/constants/rateLimits.js
+++ b/src/constants/rateLimits.js
@@ -1,0 +1,3 @@
+export const MAX_CALLS_PER_SECOND = 50
+export const MAX_CALLS_PER_MINUTE = 2000
+export const MAX_CALLS_PER_HOUR = 80000

--- a/src/constants/rateLimits.js
+++ b/src/constants/rateLimits.js
@@ -1,3 +1,3 @@
-export const MAX_CALLS_PER_SECOND = 50
-export const MAX_CALLS_PER_MINUTE = 2000
-export const MAX_CALLS_PER_HOUR = 80000
+export const MAX_CALLS_PER_SECOND = 25
+export const MAX_CALLS_PER_MINUTE = 1000
+export const MAX_CALLS_PER_HOUR = 40000

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export {
     convertFeatureToLocation,
     convertPositionToBbox,
     convertLocationToPositionDEPRECATED as convertLocationToPosition,
+    throttler,
 } from './utils'
 
 export * from './constants/travelModes'

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -280,10 +280,6 @@ declare module '@entur/sdk' {
             query: $entur$sdk$TripPatternsQuery
         ): Promise<Array<$entur$sdk$TripPattern>>,
 
-        getTripPatterns(
-            queries: Array<$entur$sdk$TripPatternsQuery>
-        ): Promise<Array<Array<$entur$sdk$TripPattern>>>,
-
         getStopPlaceDepartures(stopPlaceId: string, params?: {
             startTime?: string,
             range?: number,
@@ -322,4 +318,5 @@ declare module '@entur/sdk' {
         maxLng: number,
         maxLat: number,
     }
+    declare export function throttler(func: Function, args: Array<any>): Array<any>
 }

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -280,6 +280,10 @@ declare module '@entur/sdk' {
             query: $entur$sdk$TripPatternsQuery
         ): Promise<Array<$entur$sdk$TripPattern>>,
 
+        getTripPatterns(
+            queries: Array<$entur$sdk$TripPatternsQuery>
+        ): Promise<Array<Array<$entur$sdk$TripPattern>>>,
+
         getStopPlaceDepartures(stopPlaceId: string, params?: {
             startTime?: string,
             range?: number,

--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -15,7 +15,7 @@ import type {
     Location,
     StopPlace,
 } from '../../flow-types'
-import { convertPositionToBbox, getPromiseThrottler } from '../utils'
+import { convertPositionToBbox } from '../utils'
 
 type StopPlaceParams = {
     onForBoarding?: boolean, // deprecated
@@ -46,14 +46,13 @@ export type GetTripPatternsParams = {
     limit?: number,
     wheelchairAccessible?: boolean,
 }
-function getTripPatternsSearch(
-    params: GetTripPatternsParams,
-    url: string,
-    headers?: Object,
-): Promise<Array<TripPattern>> {
+export function getTripPatterns(searchParams: GetTripPatternsParams): Promise<Array<TripPattern>> {
+    const { host, headers } = getJourneyPlannerHost(this.config)
+    const url = `${host}/graphql`
+
     const {
         searchDate, limit, wheelchairAccessible, ...rest
-    } = { ...DEFAULT_SEARCH_PARAMS, ...params }
+    } = { ...DEFAULT_SEARCH_PARAMS, ...searchParams }
 
     const variables = {
         ...rest,
@@ -70,20 +69,6 @@ function getTripPatternsSearch(
                 return []
             }
         })
-}
-
-// eslint-disable-next-line max-len
-export function getTripPatterns(searchParams: GetTripPatternsParams | Array<GetTripPatternsParams>): Promise<Array<TripPattern>> | Promise<Array<Array<TripPattern>>> {
-    const { host, headers } = getJourneyPlannerHost(this.config)
-    const url = `${host}/graphql`
-    if (!Array.isArray(searchParams)) {
-        return getTripPatternsSearch(searchParams, url, headers)
-    }
-
-    const throttler = getPromiseThrottler(searchParams.length)
-    const searches = searchParams
-        .map(p => throttler.add(getTripPatternsSearch.bind(this, p, url, headers)))
-    return Promise.all(searches)
 }
 
 export function getStopPlaceDepartures(

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,7 @@ import lineString from 'turf-linestring'
 import point from 'turf-point'
 import bbox from '@turf/bbox'
 import destination from '@turf/destination'
+import PromiseThrottle from 'promise-throttle'
 import type { Feature } from '../flow-types/Feature'
 import type { Location } from '../flow-types/Location'
 import type { Coordinates } from '../flow-types/Coordinates'
@@ -52,4 +53,24 @@ export function convertPositionToBbox(coordinates: Coordinates, distance: number
     return {
         minLng, minLat, maxLng, maxLat,
     }
+}
+
+export function getPromiseThrottler(callCount: number): Object {
+    const maxCallsPerSecond = 50
+    const maxCallsPerMinute = 2000
+    const maxCallsPerHour = 80000
+
+    let requestsPerSecond
+    if (callCount <= maxCallsPerMinute) {
+        requestsPerSecond = maxCallsPerSecond
+    } else if (callCount <= maxCallsPerHour) {
+        requestsPerSecond = maxCallsPerMinute / 60
+    } else {
+        requestsPerSecond = maxCallsPerHour / 3600
+    }
+
+    return new PromiseThrottle({
+        requestsPerSecond,
+        promiseImplementation: Promise,
+    })
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,22 +55,23 @@ export function convertPositionToBbox(coordinates: Coordinates, distance: number
     }
 }
 
-export function getPromiseThrottler(callCount: number): Object {
+export const throttler = (func: Function, args: Array<any>): Promise<any> => {
     const maxCallsPerSecond = 50
     const maxCallsPerMinute = 2000
     const maxCallsPerHour = 80000
 
-    let requestsPerSecond
+    const callCount = args.length
+
+    let requestsPerSecond = Math.floor(maxCallsPerHour / 3600)
     if (callCount <= maxCallsPerMinute) {
         requestsPerSecond = maxCallsPerSecond
     } else if (callCount <= maxCallsPerHour) {
-        requestsPerSecond = maxCallsPerMinute / 60
-    } else {
-        requestsPerSecond = maxCallsPerHour / 3600
+        requestsPerSecond = Math.floor(maxCallsPerMinute / 60)
     }
 
-    return new PromiseThrottle({
+    const promiseThrottle = new PromiseThrottle({
         requestsPerSecond,
-        promiseImplementation: Promise,
     })
+
+    return Promise.all(args.map(a => promiseThrottle.add(func.bind(this, a))))
 }


### PR DESCRIPTION
Add generic `throttler` utility that will throttle a number of promises (sdk calls) in order to follow rate limits.