### PR TITLE
Changed to use json-to-graphql-query

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -321,7 +321,7 @@ export interface GetStopPlaceDeparturesParams {
 declare class EnturService {
   constructor(args: Config);
   journeyPlannerQuery<journeyPlannerResponse>(
-      queryObj: Object,
+      queryObj: Object | string,
       variables?: Object,
       ignoreFields?: Array<string>,
       config?: ServiceConfig,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,19 @@
+export interface Config = {
+    clientName: string,
+    hosts?: {
+        journeyPlanner?: string,
+        geocoder?: string,
+    }
+}
+
+export interface ServiceConfig = {
+    clientName: string,
+    hosts: {
+        journeyplanner: string,
+        geocoder: string,
+    },
+}
+
 export interface Alert {
   id?: string;
   alertDescriptionText: string;
@@ -303,7 +319,13 @@ export interface GetStopPlaceDeparturesParams {
 }
 
 declare class EnturService {
-  constructor(args: { clientName: string });
+  constructor(args: Config);
+  journeyPlannerQuery<journeyPlannerResponse>(
+      queryObj: Object,
+      variables?: Object,
+      ignoreFields?: Array<string>,
+      config?: ServiceConfig,
+  ): Promise<journeyPlannerResponse>;
   findTrips(
     from: string,
     to: string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2936,6 +2936,11 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-to-graphql-query": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/json-to-graphql-query/-/json-to-graphql-query-1.9.0.tgz",
+      "integrity": "sha512-SXZzxv5J7AQgdmJBkq94mIStjDxuWmecLhsNYTENm+Fzil1qyt6PiKDvq4cHjFJKXB6Qp4TedZxElyRHr7oPYw=="
+    },
     "json5": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@turf/bbox": "^6.0.1",
     "@turf/destination": "^6.0.1",
     "clean-deep": "^3.0.2",
+    "json-to-graphql-query": "^1.9.0",
     "node-fetch": "^2.3.0",
     "promise-throttle": "^1.0.0",
     "qs": "^6.6.0",

--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,6 @@
 // @flow
+import { jsonToGraphQLQuery } from 'json-to-graphql-query'
+
 import { post } from './http'
 
 import { getJourneyPlannerHost } from './config'
@@ -13,12 +15,18 @@ function errorHandler(response: Object): Object {
 }
 
 export function journeyPlannerQuery<T>(
-    query: string,
+    queryObj: Object,
     variables: Object,
+    ignoreFields?: Array<string>,
     config?: ServiceConfig,
 ): Promise<T> {
     const { host, headers } = getJourneyPlannerHost((this && this.config) || config)
     const url = `${host}/graphql`
+
+    const query = jsonToGraphQLQuery(queryObj, {
+        pretty: true,
+        ignoreFields,
+    })
 
     return post(url, {
         query,

--- a/src/api.js
+++ b/src/api.js
@@ -6,6 +6,8 @@ import { post } from './http'
 import { getJourneyPlannerHost } from './config'
 import type { ServiceConfig } from './config'
 
+const pretty = process.env.NODE_ENV !== 'production'
+
 function errorHandler(response: Object): Object {
     if (response.errors && response.errors[0]) {
         throw new Error(`GraphQL: ${response.errors[0].message}`)
@@ -15,22 +17,18 @@ function errorHandler(response: Object): Object {
 }
 
 export function journeyPlannerQuery<T>(
-    queryObj: Object,
-    variables: Object,
+    queryObj: Object | string,
+    variables?: Object,
     ignoreFields?: Array<string>,
     config?: ServiceConfig,
 ): Promise<T> {
     const { host, headers } = getJourneyPlannerHost((this && this.config) || config)
     const url = `${host}/graphql`
 
-    const query = jsonToGraphQLQuery(queryObj, {
-        pretty: true,
-        ignoreFields,
-    })
+    const query = typeof queryObj === 'string'
+        ? queryObj
+        : jsonToGraphQLQuery(queryObj, { pretty, ignoreFields })
 
-    return post(url, {
-        query,
-        variables,
-    }, headers)
+    return post(url, { query, variables }, headers)
         .then(errorHandler)
 }

--- a/src/bikeRental/index.js
+++ b/src/bikeRental/index.js
@@ -1,7 +1,8 @@
 // @flow
 import { journeyPlannerQuery } from '../api'
 
-import { getBikeRentalStationProp, getBikeRentalStationByBoxProps } from './query'
+import { getBikeRentalStationQuery, getBikeRentalStationByBoxQuery } from './query'
+
 import { convertPositionToBbox } from '../utils'
 import type { BikeRentalStation, Coordinates } from '../../flow-types'
 
@@ -10,7 +11,7 @@ export function getBikeRentalStation(stationId: string): Promise<BikeRentalStati
         id: stationId,
     }
 
-    return journeyPlannerQuery(getBikeRentalStationProp, variables, this.config)
+    return journeyPlannerQuery(getBikeRentalStationQuery, variables, undefined, this.config)
         .then(response => response.data.bikeRentalStation)
 }
 
@@ -20,6 +21,6 @@ export function getBikeRentalStations(
 ): Promise<Array<BikeRentalStation>> {
     const variables = convertPositionToBbox(coordinates, distance)
 
-    return journeyPlannerQuery(getBikeRentalStationByBoxProps, variables, this.config)
+    return journeyPlannerQuery(getBikeRentalStationByBoxQuery, variables, undefined, this.config)
         .then((response: Object = {}) => response?.data?.bikeRentalStationsByBbox || [])
 }

--- a/src/bikeRental/query.js
+++ b/src/bikeRental/query.js
@@ -1,35 +1,45 @@
-export const getBikeRentalStationByBoxProps = `
-query bikeRentalStationsByBox($minLat:Float, $minLng:Float, $maxLat:Float, $maxLng:Float) {
-  bikeRentalStationsByBbox(minimumLatitude: $minLat, minimumLongitude: $minLng, maximumLatitude: $maxLat , maximumLongitude: $maxLng) {
-    id
-    name
-    bikesAvailable
-    spacesAvailable
-    longitude
-    latitude
-  }
-}`
+// @flow
+import { VariableType } from 'json-to-graphql-query'
 
-export const getBikeRentalStationProp = `
-query bikeRentalStation($id:String!) {
-  bikeRentalStation(id:$id) {
-    id
-    name
-    bikesAvailable
-    spacesAvailable
-    longitude
-    latitude
-  }
-}`
+const bikeRentalStationFields = {
+    id: true,
+    name: true,
+    bikesAvailable: true,
+    spacesAvailable: true,
+    longitude: true,
+    latitude: true,
+}
 
-export const getBikeRentalStationsProps = `
-{
-  bikeRentalStation {
-    id
-    name
-    bikesAvailable
-    spacesAvailable
-    longitude
-    latitude
-  }
-}`
+export const getBikeRentalStationQuery = {
+    query: {
+        __variables: {
+            id: 'String!',
+        },
+        bikeRentalStation: {
+            __args: {
+                id: new VariableType('id'),
+            },
+            ...bikeRentalStationFields,
+        },
+    },
+}
+
+export const getBikeRentalStationByBoxQuery = {
+    query: {
+        __variables: {
+            minLat: 'Float',
+            minLng: 'Float',
+            maxLat: 'Float',
+            maxLng: 'Float',
+        },
+        bikeRentalStationsByBbox: {
+            __args: {
+                minimumLatitude: new VariableType('minLat'),
+                minimumLongitude: new VariableType('minLng'),
+                maximumLatitude: new VariableType('maxLat'),
+                maximumLongitude: new VariableType('maxLng'),
+            },
+            ...bikeRentalStationFields,
+        },
+    },
+}

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -59,6 +59,14 @@ type $entur$sdk$Config = {
     }
 }
 
+type $entur$sdk$ServiceConfig = {
+    clientName: string,
+    hosts: {
+        journeyplanner: string,
+        geocoder: string,
+    },
+}
+
 type $entur$sdk$Notice = {|
     text: string,
 |}
@@ -290,6 +298,13 @@ type $entur$sdk$BikeRentalStation = {
 declare module '@entur/sdk' {
     declare export default class EnturService {
         constructor(config?: $entur$sdk$Config): EnturService;
+
+        journeyPlannerQuery<$entur$sdk$journeyPlannerResponse>(
+            queryObj: Object,
+            variables?: Object,
+            ignoreFields?: Array<string>,
+            config?: $entur$sdk$ServiceConfig,
+        ): Promise<$entur$sdk$journeyPlannerResponse>,
 
         getFeatures(
             query: string,

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -300,7 +300,7 @@ declare module '@entur/sdk' {
         constructor(config?: $entur$sdk$Config): EnturService;
 
         journeyPlannerQuery<$entur$sdk$journeyPlannerResponse>(
-            queryObj: Object,
+            queryObj: Object | string,
             variables?: Object,
             ignoreFields?: Array<string>,
             config?: $entur$sdk$ServiceConfig,

--- a/src/service.js
+++ b/src/service.js
@@ -1,4 +1,5 @@
 // @flow
+import { journeyPlannerQuery } from './api'
 import {
     getTripPatterns, getStopPlaceDepartures, findTrips,
 } from './trip'
@@ -15,6 +16,8 @@ class EnturService {
     constructor(config: ArgumentConfig) {
         this.config = getServiceConfig(config)
     }
+
+    journeyPlannerQuery = journeyPlannerQuery
 
     getFeatures = getFeatures
 

--- a/src/stopPlace/index.js
+++ b/src/stopPlace/index.js
@@ -1,7 +1,7 @@
 // @flow
 import { journeyPlannerQuery } from '../api'
 
-import { getStopPlaceProps, getStopPlacesByBboxProps } from './query'
+import { getStopPlaceQuery, getStopPlacesByBboxQuery } from './query'
 
 import { convertPositionToBbox } from '../utils'
 
@@ -10,7 +10,7 @@ import type { Coordinates, StopPlace } from '../../flow-types'
 export function getStopPlace(id: string): Promise<StopPlace> {
     const variables = { id }
 
-    return journeyPlannerQuery(getStopPlaceProps, variables, this.config)
+    return journeyPlannerQuery(getStopPlaceQuery, variables, undefined, this.config)
         .then((response: Object = {}) => {
             if (!response?.data?.stopPlace) {
                 throw new Error(`Could not find stop place with ID "${id}"`)
@@ -25,7 +25,7 @@ export function getStopPlacesByPosition(
 ): Promise<Array<StopPlace>> {
     const variables = convertPositionToBbox(coordinates, distance)
 
-    return journeyPlannerQuery(getStopPlacesByBboxProps, variables, this.config)
+    return journeyPlannerQuery(getStopPlacesByBboxQuery, variables, undefined, this.config)
         .then((response: Object = {}) => {
             if (!response?.data?.stopPlacesByBbox) {
                 return []

--- a/src/stopPlace/query.js
+++ b/src/stopPlace/query.js
@@ -1,55 +1,60 @@
 // @flow
-import { situationFields, situationFragment } from '../trip/queryHelper'
+import { VariableType } from 'json-to-graphql-query'
 
-export const getStopPlaceProps = `
-    query StopPlace($id:String!) {
-        stopPlace(id:$id) {
-            id
-            name
-            latitude
-            longitude
-            description
-            wheelchairBoarding
-            weighting
-            transportMode
-            transportSubmode
-            quays { ...quayFields }
-        }
+import { situationFields } from '../trip/queryHelper'
 
-    }
+const quayFields = {
+    id: true,
+    publicCode: true,
+    description: true,
+}
 
-    fragment quayFields on Quay {
-        id
-        publicCode
-        description
-        ${situationFields}
-    }
-    ${situationFragment}
-`
+const stopPlaceFields = {
+    id: true,
+    name: true,
+    description: true,
+    latitude: true,
+    longitude: true,
+    wheelchairBoarding: true,
+    weighting: true,
+    transportMode: true,
+    transportSubmode: true,
+    quays: {
+        ...quayFields,
+        situations: situationFields,
+    },
+}
 
+export const getStopPlaceQuery = {
+    query: {
+        __variables: {
+            id: 'String!',
+        },
+        stopPlace: {
+            __args: {
+                id: new VariableType('id'),
+            },
+            ...stopPlaceFields,
+        },
+    },
+}
 
-export const getStopPlacesByBboxProps = `
-    query StopPlacesByBboxProps($minLat:Float, $minLng:Float, $maxLng:Float, $maxLat:Float) {
-        stopPlacesByBbox(minimumLatitude:$minLat, minimumLongitude:$minLng, maximumLatitude:$maxLat, maximumLongitude:$maxLng) {
-            id
-            name
-            latitude
-            longitude
-            description
-            wheelchairBoarding
-            weighting
-            transportMode
-            transportSubmode
-            quays { ...quayFields }
-        }
-
-    }
-
-    fragment quayFields on Quay {
-        id
-        publicCode
-        description
-        ${situationFields}
-    }
-    ${situationFragment}
-`
+export const getStopPlacesByBboxQuery = {
+    query: {
+        __variables: {
+            minLat: 'Float',
+            minLng: 'Float',
+            maxLng: 'Float',
+            maxLat: 'Float',
+        },
+        stopPlacesByBbox: {
+            __args: {
+                minimumLatitude: new VariableType('minLat'),
+                minimumLongitude: new VariableType('minLng'),
+                maximumLatitude: new VariableType('maxLat'),
+                maximumLongitude: new VariableType('maxLng'),
+            },
+            ...stopPlaceFields,
+        },
+    },
+}

--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -3,9 +3,10 @@ import { journeyPlannerQuery } from '../api'
 import {
     FOOT, BUS, TRAM, RAIL, METRO, WATER, AIR,
 } from '../constants/travelModes'
+
 import {
-    getItinerariesProps,
-    getStopPlaceDeparturesProps,
+    getTripPatternQuery,
+    getStopPlaceDeparturesQuery,
 } from './query'
 
 import type {
@@ -25,6 +26,7 @@ type StopPlaceParams = {
 const DEFAULT_SEARCH_PARAMS = {
     arriveBy: false,
     modes: [FOOT, BUS, TRAM, RAIL, METRO, WATER, AIR],
+    transportSubmode: [],
     limit: 5,
     wheelchairAccessible: false,
 }
@@ -44,7 +46,9 @@ export type GetTripPatternsParams = {
     limit?: number,
     wheelchairAccessible?: boolean,
 }
-export function getTripPatterns(searchParams: GetTripPatternsParams): Promise<Array<TripPattern>> {
+export function getTripPatterns(
+    searchParams: GetTripPatternsParams,
+): Promise<Array<TripPattern>> {
     const {
         searchDate, limit, wheelchairAccessible, ...rest
     } = { ...DEFAULT_SEARCH_PARAMS, ...searchParams }
@@ -56,7 +60,7 @@ export function getTripPatterns(searchParams: GetTripPatternsParams): Promise<Ar
         wheelchair: wheelchairAccessible,
     }
 
-    return journeyPlannerQuery(getItinerariesProps, variables, this.config)
+    return journeyPlannerQuery(getTripPatternQuery, variables, undefined, this.config)
         .then((response: Object = {}) => response?.data?.trip?.tripPatterns || [])
 }
 
@@ -117,7 +121,7 @@ export function getStopPlaceDepartures(
         omitNonBoarding,
     }
 
-    return journeyPlannerQuery(getStopPlaceDeparturesProps, variables, this.config)
+    return journeyPlannerQuery(getStopPlaceDeparturesQuery, variables, undefined, this.config)
         .then((response: Object = {}) => {
             if (!response || !response.data) {
                 throw new Error(`Entur SDK: Could not fetch departures for ids: ${JSON.stringify(stopPlaceIds)}`)

--- a/src/trip/query.js
+++ b/src/trip/query.js
@@ -1,121 +1,170 @@
 // @flow
+import { VariableType } from 'json-to-graphql-query'
+
 import {
-    placeFields,
-    lineFields,
-    intermediateEstimatedCallFields,
-    placeFragment,
-    lineFragment,
+    noticeFields,
     situationFields,
-    intermediateEstimatedCallFragment,
-    situationFragment,
+    lineFields,
+    estimatedCallFields,
+    intermediateEstimatedCallFields,
 } from './queryHelper'
 
+const journeyPatternFields = {
+    id: true,
+    name: true,
+    line: lineFields,
+    notices: noticeFields,
+}
 
-export const getItinerariesProps = `
-    query tripPatterns($numTripPatterns:Int!,$wheelchair:Boolean!,$from:Location!,$to:Location!,$dateTime:DateTime!,$arriveBy:Boolean!,$modes:[Mode]!){
-        trip(
-            numTripPatterns: $numTripPatterns
-            wheelchair: $wheelchair
-            from: $from
-            to: $to
-            dateTime: $dateTime
-            arriveBy: $arriveBy
-            modes: $modes
-        ) {
-            tripPatterns {
-                startTime
-                endTime
-                duration
-                waitingTime
-                walkDistance
-                legs { ...legFields }
-            }
-        }
-    }
+const serviceJourneyFields = {
+    id: true,
+    privateCode: true,
+    linePublicCode: true,
+    wheelchairAccessible: true,
+    journeyPattern: journeyPatternFields,
+    notices: noticeFields,
+    situations: situationFields,
+}
 
-    fragment legFields on Leg {
-        mode
-        aimedStartTime
-        aimedEndTime
-        expectedStartTime
-        expectedEndTime
-        realtime
-        distance
-        duration
-        pointsOnLink { points length }
-        ${placeFields}
-        intermediateQuays { id name description publicCode }
-        authority { id name }
-        operator { id name url }
-        ${lineFields}
-        serviceJourney { ...serviceJourneyFields }
-        ${intermediateEstimatedCallFields}
-        ride
-    }
+const quayFields = {
+    id: true,
+    publicCode: true,
+    description: true,
+}
 
-    ${placeFragment}
+const placeFields = {
+    name: true,
+    latitude: true,
+    longitude: true,
+    quay: {
+        ...quayFields,
+        name: true,
+        situations: situationFields,
+    },
+}
 
-    ${lineFragment}
+const legFields = {
+    mode: true,
+    aimedStartTime: true,
+    aimedEndTime: true,
+    expectedStartTime: true,
+    expectedEndTime: true,
+    realtime: true,
+    distance: true,
+    duration: true,
+    ride: true,
 
-    fragment serviceJourneyFields on ServiceJourney {
-      id
-      privateCode
-      linePublicCode
-      wheelchairAccessible
-      journeyPattern { notices { text } }
-      notices { text }
-      ${situationFields}
-    }
+    fromPlace: placeFields,
+    toPlace: placeFields,
+    serviceJourney: serviceJourneyFields,
+    line: lineFields,
+    intermediateQuays: {
+        id: true,
+        name: true,
+        description: true,
+        publicCode: true,
+    },
+    intermediateEstimatedCalls: {
+        ...estimatedCallFields,
+        ...intermediateEstimatedCallFields,
+    },
 
-    ${intermediateEstimatedCallFragment}
+    pointsOnLink: {
+        points: true,
+        length: true,
+    },
+    authority: {
+        id: true,
+        name: true,
+    },
+    operator: {
+        id: true,
+        name: true,
+        url: true,
+    },
+}
 
-    ${situationFragment}
-`
+export const getTripPatternQuery = {
+    query: {
+        __variables: {
+            numTripPatterns: 'Int!',
+            from: 'Location!',
+            to: 'Location!',
+            dateTime: 'DateTime!',
+            arriveBy: 'Boolean!',
+            wheelchair: 'Boolean!',
+            modes: '[Mode]!',
 
-export const getStopPlaceDeparturesProps = `
-    query StopPlaceDepartures($ids:[String]!,$start:DateTime!,$range:Int!,$departures:Int!,$omitNonBoarding:Boolean!) {
-        stopPlaces(ids:$ids) {
-          id
-          estimatedCalls(startTime:$start, timeRange:$range, numberOfDepartures:$departures, omitNonBoarding:$omitNonBoarding) { ...estimatedCallFields }
-        }
-    }
+        },
+        trip: {
+            __args: {
+                numTripPatterns: new VariableType('numTripPatterns'),
+                from: new VariableType('from'),
+                to: new VariableType('to'),
+                dateTime: new VariableType('dateTime'),
+                arriveBy: new VariableType('arriveBy'),
+                wheelchair: new VariableType('wheelchair'),
+                modes: new VariableType('modes'),
+            },
+            tripPatterns: {
+                startTime: true,
+                endTime: true,
+                duration: true,
+                waitingTime: true,
+                walkDistance: true,
+                legs: legFields,
+            },
+        },
+    },
+}
 
-    fragment estimatedCallFields on EstimatedCall {
-        aimedDepartureTime
-        expectedDepartureTime
-        realtime
-        forBoarding
-        forAlighting
-        date
-        destinationDisplay { frontText }
-        notices { text }
-        quay { ...quayFields }
-        serviceJourney { ...serviceJourneyFields }
-    }
-
-    fragment quayFields on Quay {
-        id
-        publicCode
-        description
-        ${situationFields}
-    }
-
-    fragment serviceJourneyFields on ServiceJourney {
-      id
-      journeyPattern { ...journeyPatternFields }
-      notices { text }
-      transportSubmode
-      ${situationFields}
-    }
-
-    fragment journeyPatternFields on JourneyPattern {
-      id
-      name
-      ${lineFields}
-      notices { text }
-    }
-
-    ${lineFragment}
-
-    ${situationFragment}
-`
+export const getStopPlaceDeparturesQuery = {
+    query: {
+        __variables: {
+            ids: '[String]!',
+            start: 'DateTime!',
+            range: 'Int!',
+            departures: 'Int!',
+            omitNonBoarding: 'Boolean!',
+        },
+        stopPlaces: {
+            __args: {
+                ids: new VariableType('ids'),
+            },
+            id: true,
+            estimatedCalls: {
+                __args: {
+                    startTime: new VariableType('start'),
+                    timeRange: new VariableType('range'),
+                    numberOfDepartures: new VariableType('departures'),
+                    omitNonBoarding: new VariableType('omitNonBoarding'),
+                },
+                aimedDepartureTime: true,
+                expectedDepartureTime: true,
+                realtime: true,
+                forBoarding: true,
+                forAlighting: true,
+                date: true,
+                destinationDisplay: {
+                    frontText: true,
+                },
+                notices: noticeFields,
+                quay: {
+                    ...quayFields,
+                    situations: situationFields,
+                },
+                serviceJourney: {
+                    id: true,
+                    journeyPattern: {
+                        id: true,
+                        name: true,
+                        line: lineFields,
+                        notices: noticeFields,
+                    },
+                    notices: noticeFields,
+                    transportSubmode: true,
+                },
+            },
+        },
+    },
+}

--- a/src/trip/queryHelper.js
+++ b/src/trip/queryHelper.js
@@ -1,70 +1,55 @@
-/*
- * Common query fields and fragments used in Journeyplanner queries.
- * Interpolate them into the query strings wherever they are needed.
- */
+// @flow
+export const noticeFields = {
+    text: true,
+}
 
-const placeFieldsKey = 'placeFields'
+export const situationFields = {
+    situationNumber: true,
+    summary: { value: true },
+    description: { value: true },
+    detail: { value: true },
+    validityPeriod: {
+        startTime: true,
+        endTime: true,
+    },
+    reportType: true,
+    infoLink: true,
+}
 
-const lineFieldsKey = 'lineFields'
+export const lineFields = {
+    id: true,
+    publicCode: true,
+    name: true,
+    transportMode: true,
+    description: true,
+    presentation: {
+        colour: true,
+        textColour: true,
+    },
+    authority: {
+        id: true,
+        name: true,
+    },
+    notices: noticeFields,
+    situations: situationFields,
+}
 
-const intEstimatedCallFieldsKey = 'intEstimatedCallFields'
+export const estimatedCallFields = {
+    date: true,
+    forBoarding: true,
+    forAlighting: true,
+}
 
-const situationFieldsKey = 'situationFields'
-const situationFieldsVal = `situations { ...${situationFieldsKey} }`
-
-
-export const placeFields = `
-    fromPlace { ...${placeFieldsKey} }
-    toPlace { ...${placeFieldsKey} }`
-
-export const placeFragment = `
-        fragment ${placeFieldsKey} on Place {
-          name
-          latitude
-          longitude
-          quay {
-            id
-            name
-            description
-            publicCode
-            ${situationFieldsVal}
-          }
-        }`
-export const lineFields = `line { ...${lineFieldsKey} }`
-export const lineFragment = `
-    fragment ${lineFieldsKey} on Line {
-      id
-      publicCode
-      name
-      transportMode
-      description
-      presentation { colour textColour }
-      authority { id name }
-      notices { text }
-      ${situationFieldsVal}
-    }`
-
-export const intermediateEstimatedCallFields = `intermediateEstimatedCalls { ...${intEstimatedCallFieldsKey} }`
-export const intermediateEstimatedCallFragment = `
-    fragment ${intEstimatedCallFieldsKey} on EstimatedCall {
-      quay { id name stopPlace { id } }
-      forAlighting
-      forBoarding
-      expectedArrivalTime
-      expectedDepartureTime
-      aimedArrivalTime
-      aimedDepartureTime
-      date
-    }`
-
-export const situationFields = situationFieldsVal
-export const situationFragment = `
-    fragment ${situationFieldsKey} on PtSituationElement {
-      situationNumber
-      summary { value }
-      description { value }
-      detail { value }
-      validityPeriod { startTime endTime }
-      reportType
-      infoLink
-    }`
+export const intermediateEstimatedCallFields = {
+    quay: {
+        id: true,
+        name: true,
+        stopPlace: {
+            id: true,
+        },
+    },
+    expectedArrivalTime: true,
+    expectedDepartureTime: true,
+    aimedArrivalTime: true,
+    aimedDepartureTime: true,
+}


### PR DESCRIPTION
Changes:
- GraphQL queries structured as `json-to-graphql-query` objects instead of hardcoded strings
- Added journeyPlannerQuery to service for supporting raw journey planner queries
- updated flow and typescript definitions

Features:
- journeyPlannerQuery metod in service instance