### PR TITLE
Force return order 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
         "fetch": false
     },
     "rules": {
+        "arrow-body-style": 0,
         "import/prefer-default-export": "off",
         "indent": ["error", 4, {"SwitchCase": 1}],
         "semi": ["error", "never"]

--- a/index.d.ts
+++ b/index.d.ts
@@ -507,7 +507,7 @@ declare class EnturService {
   getDeparturesFromStopPlaces(
       stopPlaceIds: Array<string>,
       params?: GetDeparturesParams,
-  ): Promise<StopPlaceDepartures[]>;
+  ): Promise<Array<StopPlaceDepartures | undefined>>;
 
   getDeparturesFromStopPlace(
       stopPlaceId: string,
@@ -517,7 +517,7 @@ declare class EnturService {
   getDeparturesFromQuays(
       quayIds: Array<string>,
       params?: GetDeparturesParams,
-  ): Promise<QuayDepartures[]>;
+  ): Promise<Array<QuayDepartures | undefined>>;
 
   getDeparturesBetweenStopPlaces(
       fromStopPlaceId: string,
@@ -533,7 +533,7 @@ declare class EnturService {
   getStopPlaces(
       stopPlaceId: Array<string>,
       params?: StopPlaceParams,
-  ): Promise<StopPlaceDetails>;
+  ): Promise<Array<StopPlaceDetails undefined>>;
 
   getStopPlacesByPosition(
     coordinates: Coordinates,

--- a/src/departure/index.js
+++ b/src/departure/index.js
@@ -4,6 +4,8 @@ import {
     BUS, TRAM, RAIL, METRO, WATER, AIR, COACH, CAR,
 } from '../constants/travelModes'
 
+import { forceOrder } from '../utils'
+
 import {
     getDeparturesFromStopPlacesQuery,
     getDeparturesFromQuayQuery,
@@ -30,7 +32,7 @@ type GetDeparturesParams = {
 export function getDeparturesFromStopPlaces(
     stopPlaceIds: Array<string>,
     params?: GetDeparturesParams = {},
-): Promise<Array<StopPlaceDepartures>> {
+): Promise<Array<StopPlaceDepartures | void>> {
     const {
         limit = 50,
         timeRange = 72000,
@@ -59,6 +61,9 @@ export function getDeparturesFromStopPlaces(
                 departures: estimatedCalls.map(destinationMapper),
             }))
         })
+        .then((stopPlaces: Array<StopPlaceDepartures>) => {
+            return forceOrder<StopPlaceDepartures>(stopPlaces, stopPlaceIds, ({ id }) => id)
+        })
 }
 
 export function getDeparturesFromStopPlace(
@@ -66,13 +71,13 @@ export function getDeparturesFromStopPlace(
     params?: GetDeparturesParams,
 ): Promise<Array<Departure>> {
     return getDeparturesFromStopPlaces.call(this, [stopPlaceId], params)
-        .then((stopPlaces: Array<StopPlaceDepartures>) => stopPlaces?.[0]?.departures || [])
+        .then((stopPlaces: Array<StopPlaceDepartures | void>) => stopPlaces[0]?.departures || [])
 }
 
 export function getDeparturesFromQuays(
     quayIds: Array<string>,
     params?: GetDeparturesParams = {},
-): Promise<Array<QuayDepartures>> {
+): Promise<Array<QuayDepartures | void>> {
     const {
         limit = 30,
         timeRange = 72000,
@@ -99,6 +104,9 @@ export function getDeparturesFromQuays(
                 ...stopPlace,
                 departures: estimatedCalls.map(destinationMapper),
             }))
+        })
+        .then((quayDepartures: Array<QuayDepartures>) => {
+            return forceOrder<QuayDepartures>(quayDepartures, quayIds, ({ id }) => id)
         })
 }
 

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -518,7 +518,7 @@ declare module '@entur/sdk' {
         getDeparturesFromStopPlaces(
             stopPlaceIds: Array<string>,
             params?: $entur$sdk$GetDeparturesParams,
-        ): Promise<Array<$entur$sdk$StopPlaceDepartures>>,
+        ): Promise<Array<$entur$sdk$StopPlaceDepartures | void>>,
 
         getDeparturesFromStopPlace(
             stopPlaceId: string,
@@ -528,7 +528,7 @@ declare module '@entur/sdk' {
         getDeparturesFromQuays(
             quayIds: Array<string>,
             params?: $entur$sdk$GetDeparturesParams,
-        ): Promise<Array<$entur$sdk$QuayDepartures>>,
+        ): Promise<Array<$entur$sdk$QuayDepartures | void>>,
 
         getDeparturesBetweenStopPlaces(
             fromStopPlaceId: string,
@@ -544,7 +544,7 @@ declare module '@entur/sdk' {
         getStopPlaces(
             stopPlaceIds: Array<string>,
             params?: $entur$sdk$StopPlaceParams,
-        ): Promise<Array<$entur$sdk$StopPlaceDetails>>,
+        ): Promise<Array<$entur$sdk$StopPlaceDetails | void>>,
 
         getStopPlacesByPosition(
             coordinates: $entur$sdk$Coordinates,

--- a/src/stopPlace/index.js
+++ b/src/stopPlace/index.js
@@ -9,7 +9,7 @@ import {
     getQuaysForStopPlaceQuery,
 } from './query'
 
-import { convertPositionToBbox } from '../utils'
+import { convertPositionToBbox, forceOrder } from '../utils'
 
 import type { Quay, Coordinates } from '../../flow-types'
 import type { StopPlaceDetails, StopPlaceFacilities } from '../../flow-types/StopPlace'
@@ -34,7 +34,7 @@ export function getStopPlace(
 export function getStopPlaces(
     stopPlaceIds: Array<string>,
     params?: StopPlaceParams = {},
-): Promise<Array<StopPlaceDetails>> {
+): Promise<Array<StopPlaceDetails | void>> {
     const { includeUnusedQuays = true, ...rest } = params
     const variables = {
         ids: stopPlaceIds,
@@ -44,6 +44,9 @@ export function getStopPlaces(
 
     return journeyPlannerQuery(getStopPlacesQuery, variables, undefined, this.config)
         .then((data: Object) => data?.stopPlaces || [])
+        .then((stopPlaceDetails: Array<StopPlaceDetails>) => {
+            return forceOrder<StopPlaceDetails>(stopPlaceDetails, stopPlaceIds, ({ id }) => id)
+        })
 }
 
 export function getStopPlacesByPosition(

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,3 +78,19 @@ export function uniqBy<T>(arr: Array<T>, predicate: (T) => any): Array<T> {
         return map
     }, new Map()).values()]
 }
+
+export function forceOrder<T>(
+    list: Array<T>,
+    sequence: Array<any>,
+    predicate?: (T) => any = item => item,
+): Array<T | void> {
+    return list.reduce((arr: Array<T | void>, item: T) => {
+        const index = sequence.indexOf(predicate(item))
+        if (index > -1) {
+            // eslint-disable-next-line no-param-reassign
+            arr[index] = item
+        }
+
+        return arr
+    }, new Array(sequence.length).fill(undefined))
+}

--- a/test.js
+++ b/test.js
@@ -15,6 +15,7 @@ const LILLEHAMMER_STASJON = 'NSR:StopPlace:420'
 const HAMAR_STASJON = 'NSR:StopPlace:219'
 const JERNBANETORGET = 'NSR:StopPlace:58366'
 const OSLO_S = 'NSR:StopPlace:59872'
+const MISSING = 'NSR:StopPlace:5483957348574389'
 
 const { default: EnturService } = require('./src')
 
@@ -29,6 +30,7 @@ function getMetodToRun(name) {
         case 'getStopPlaces':
             return service.getStopPlaces([
                 OSLO_S,
+                MISSING,
                 JERNBANETORGET,
                 HAMAR_STASJON,
                 LILLEHAMMER_STASJON,


### PR DESCRIPTION
Ensures input order in ids arrays is identical to output order. Inserts `undefined` for unknown entries. Added to `getDeparturesFromStopPlaces`, `getDeparturesFromQuays`, `getStopPlaces`