### PR TITLE
Add 'networks' field to bikerentalstations

### DIFF
--- a/flow-types/BikeRentalStation.js
+++ b/flow-types/BikeRentalStation.js
@@ -7,4 +7,5 @@ export type BikeRentalStation = {
     spacesAvailable: number,
     longitude: number,
     latitude: number,
+    networks: Array<string>,
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -62,6 +62,7 @@ export interface BikeRentalStation {
     spacesAvailable: number;
     longitude: number;
     latitude: number;
+    networks: Array<string>
 }
 
 

--- a/src/bikeRental/query.js
+++ b/src/bikeRental/query.js
@@ -8,6 +8,7 @@ const bikeRentalStationFields = {
     spacesAvailable: true,
     longitude: true,
     latitude: true,
+    networks: true,
 }
 
 export const getBikeRentalStationQuery = {


### PR DESCRIPTION
Request to get the networks field as well from graphql.

Heres the reponse from some testing:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/26689337/53402036-41f3c480-39b1-11e9-9574-54b58ac259e6.png">
