### PR TITLE
Warn about misconfiguring service

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -26,11 +26,25 @@ const HOST_CONFIG = {
     geocoder: 'https://api.entur.io/geocoder/v1',
 }
 
+const topLevelConfigKeys = ['clientName', 'hosts']
+
 export function getServiceConfig(config: ArgumentConfig): ServiceConfig {
     if (!config || !config.clientName) {
         throw new Error('ERROR: You must pass a "clientName" to EnturService through the config argument. '
             + 'See https://www.entur.org/dev/api/header/ for information.\n')
     }
+
+    Object.keys(HOST_CONFIG).forEach((hostConfigKey) => {
+        if (hostConfigKey in config) {
+            console.warn(`"${hostConfigKey}" is not a top-level config property. Did you mean to put it in the "hosts" object?`)
+        }
+    })
+
+    Object.keys(config).forEach((key) => {
+        if (!topLevelConfigKeys.includes(key)) {
+            console.warn(`"${key}" is not a recognized config property, and will have no effect.`)
+        }
+    })
 
     const { hosts = {}, ...rest } = config
 


### PR DESCRIPTION
Prints a warning if config has typos, or if `geocoder` and `journeyplanner` hosts are put on the top level, or if some unknown properties are added.