### PR TITLE
Add getParentStopPlace method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -536,6 +536,11 @@ declare class EnturService {
       params?: StopPlaceParams,
   ): Promise<Array<StopPlaceDetails undefined>>;
 
+  getParentStopPlace(
+    id: string,
+    params?: StopPlaceParams,
+): Promise<StopPlaceDetails | null>;
+
   getStopPlacesByPosition(
     coordinates: Coordinates,
     distance?: number,

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,7 +916,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -3046,7 +3046,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
@@ -3089,7 +3089,7 @@
     },
     "lodash.isempty": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
       "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isplainobject": {
@@ -3208,7 +3208,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -3539,7 +3539,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -3663,7 +3663,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "optional": true,
@@ -4224,7 +4224,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -547,6 +547,11 @@ declare module '@entur/sdk' {
             params?: $entur$sdk$StopPlaceParams,
         ): Promise<Array<$entur$sdk$StopPlaceDetails | void>>,
 
+        getParentStopPlace(
+            stopPlaceId: string,
+            params?: $entur$sdk$StopPlaceParams,
+        ): Promise<$entur$sdk$StopPlaceDetails | null>,
+
         getStopPlacesByPosition(
             coordinates: $entur$sdk$Coordinates,
             distance?: number,

--- a/src/service.js
+++ b/src/service.js
@@ -14,6 +14,7 @@ import {
 import {
     getStopPlace,
     getStopPlaces,
+    getParentStopPlace,
     getStopPlacesByPosition,
     getStopPlaceFacilities,
     getQuaysForStopPlace,
@@ -58,6 +59,8 @@ class EnturService {
     getStopPlace = getStopPlace
 
     getStopPlaces = getStopPlaces
+
+    getParentStopPlace = getParentStopPlace
 
     getStopPlacesByPosition = getStopPlacesByPosition
 

--- a/src/stopPlace/index.js
+++ b/src/stopPlace/index.js
@@ -4,6 +4,7 @@ import { journeyPlannerQuery, nsrQuery } from '../api'
 import {
     getStopPlaceQuery,
     getStopPlacesQuery,
+    getParentStopPlaceQuery,
     getStopPlacesByBboxQuery,
     getStopPlaceFacilitiesQuery,
     getQuaysForStopPlaceQuery,
@@ -47,6 +48,21 @@ export function getStopPlaces(
         .then((stopPlaceDetails: Array<StopPlaceDetails>) => {
             return forceOrder<StopPlaceDetails>(stopPlaceDetails, stopPlaceIds, ({ id }) => id)
         })
+}
+
+export function getParentStopPlace(
+    stopPlaceId: string,
+    params?: StopPlaceParams = {},
+): Promise<StopPlaceDetails> {
+    const { includeUnusedQuays = true, ...rest } = params
+    const variables = {
+        id: stopPlaceId,
+        filterByInUse: !includeUnusedQuays,
+        ...rest,
+    }
+
+    return journeyPlannerQuery(getParentStopPlaceQuery, variables, undefined, this.config)
+        .then((data: Object = {}) => data?.stopPlace?.parent)
 }
 
 export function getStopPlacesByPosition(

--- a/src/stopPlace/query.js
+++ b/src/stopPlace/query.js
@@ -52,6 +52,21 @@ export const getStopPlacesQuery = {
     },
 }
 
+export const getParentStopPlaceQuery = {
+    query: {
+        __variables: {
+            id: 'String!',
+            filterByInUse: 'Boolean',
+        },
+        stopPlace: {
+            __args: {
+                id: new VariableType('id'),
+            },
+            parent: stopPlaceFields,
+        },
+    },
+}
+
 export const getStopPlacesByBboxQuery = {
     query: {
         __variables: {


### PR DESCRIPTION
Finds the parent stop place for a given stop place.

Example: Finding the multi modal Jernbanetorget given one of the child tram stop's id. https://api.entur.org/doc/shamash-journeyplanner/?query={stopPlace(id%3A"NSR%3AStopPlace%3A4004")%20{%20id%20name%20parent%20{id%20name}}}