### PR TITLE
Set name as an optional argument in Location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 lib/
 .DS_Store
+.idea

--- a/flow-types/Location.js
+++ b/flow-types/Location.js
@@ -2,7 +2,7 @@
 import type { Coordinates } from './Coordinates'
 
 export type Location = {
-    name: string,
+    name?: string,
     place?: string,
     coordinates?: Coordinates,
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -137,7 +137,7 @@ export interface Feature {
 }
 
 export interface Location {
-    name: string;
+    name?: string;
     place?: string;
     coordinates?: Coordinates;
 }

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -138,7 +138,7 @@ type $entur$sdk$Feature = {
 }
 
 type $entur$sdk$Location = {
-    name: string,
+    name?: string,
     place?: string,
     coordinates?: $entur$sdk$Coordinates,
 }


### PR DESCRIPTION
`name` is not a required argument in the GraphQL API.

Ref https://github.com/entur/sdk/issues/59#issue-440626283