### PR TITLE
Allow for whitelisting lines and authorities in departures

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -350,6 +350,8 @@ export interface GetDeparturesParams {
     limit?: number;
     start?: Date;
     timeRange?: number;
+    whiteListedLines?: Array<string>;
+    whiteListedAuthorities?: Array<string>;
 }
 
 export interface GetDeparturesBetweenStopPlacesParams = {

--- a/src/departure/index.js
+++ b/src/departure/index.js
@@ -28,6 +28,8 @@ type GetDeparturesParams = {
     limit?: number,
     start?: Date,
     timeRange?: number,
+    whiteListedLines?: Array<string>,
+    whiteListedAuthorities?: Array<string>,
 }
 
 export function getDeparturesFromStopPlaces(
@@ -39,6 +41,8 @@ export function getDeparturesFromStopPlaces(
         timeRange = 72000,
         start = new Date(),
         includeNonBoarding = false,
+        whiteListedLines,
+        whiteListedAuthorities,
         ...rest
     } = params
 
@@ -48,6 +52,8 @@ export function getDeparturesFromStopPlaces(
         omitNonBoarding: !includeNonBoarding,
         timeRange,
         limit,
+        whiteListedLines,
+        whiteListedAuthorities,
         ...rest,
     }
 

--- a/src/departure/query.js
+++ b/src/departure/query.js
@@ -36,6 +36,8 @@ export const getDeparturesFromStopPlacesQuery = {
             timeRange: 'Int!',
             limit: 'Int!',
             omitNonBoarding: 'Boolean!',
+            whiteListedLines: '[String!]',
+            whiteListedAuthorities: '[String!]',
         },
         stopPlaces: {
             __args: {
@@ -48,6 +50,10 @@ export const getDeparturesFromStopPlacesQuery = {
                     timeRange: new VariableType('timeRange'),
                     numberOfDepartures: new VariableType('limit'),
                     omitNonBoarding: new VariableType('omitNonBoarding'),
+                    whiteListed: {
+                        lines: new VariableType('whiteListedLines'),
+                        authorities: new VariableType('whiteListedAuthorities'),
+                    },
                 },
                 ...departureFields,
             },

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -394,6 +394,8 @@ type $entur$sdk$GetDeparturesParams = {
     limit?: number,
     departures?: number, // deprecated
     timeRange?: number,
+    whiteListedLines?: Array<string>,
+    whiteListedAuthorities?: Array<string>,
 }
 
 type $entur$sdk$GetDeparturesBetweenStopPlacesParams = {


### PR DESCRIPTION
Because one can do it in the GraphQL API.

F.ex as in this [Shamash call](https://api.entur.org/doc/shamash-journeyplanner/?query=%7B%0A%20%20stopPlace(id%3A%22NSR%3AStopPlace%3A59601%22)%20%7B%0A%20%20%20%20id%0A%20%20%20%20name%0A%20%20%20%20estimatedCalls(startTime%3A%20%222019-05-23T12%3A00%3A43%2B0100%22%2C%20whiteListed%3A%20%7B%0A%20%20%20%20%20%20lines%3A%20%5B%22RUT%3ALine%3A12%22%5D%0A%20%20%20%20%7D)%20%7B%0A%20%20%20%20%20%20aimedArrivalTime%0A%20%20%20%20%20%20realtime%0A%20%20%20%20%20%20destinationDisplay%20%7B%0A%20%20%20%20%20%20%20%20frontText%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20serviceJourney%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%0A%20%20%20%20%20%20%20%20line%20%7B%0A%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A):

```
{
  stopPlace(id:"NSR:StopPlace:59601") {
    id
    name
    estimatedCalls(startTime: "2019-05-23T12:00:43+0100", whiteListed: {
      lines: ["RUT:Line:12"]
    }) {
      aimedArrivalTime
      realtime
      destinationDisplay {
        frontText
      }
      serviceJourney {
        id
      
        line {
          id
          name
        }
      }
    }
  }
}
```
