### PR TITLE
Added optional language params to MultilingualString

### DIFF
--- a/flow-types/MultilingualString.js
+++ b/flow-types/MultilingualString.js
@@ -2,5 +2,6 @@
 
 export type MultilingualString = {
     lang: 'eng' | 'nob' | 'nno',
+    language?: 'en' | 'nb' | 'nn' | 'no',
     value: string,
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ export interface Coordinates {
 
 export interface MultilingualString {
     lang: 'eng' | 'nob' | 'nno';
+    language?: 'en' | 'nb' | 'nn' | 'no';
     value: string;
 }
 

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -21,6 +21,7 @@ type $entur$sdk$Coordinates = {
 
 type $entur$sdk$MultilingualString = {
     lang: 'eng' | 'nob' | 'nno',
+    language?: 'en' | 'nb' | 'nn' | 'no',
     value: string,
 }
 


### PR DESCRIPTION
We may get `language: 'no'` for a situation in a tripPattern, need to add this to the flow-type.