### PR TITLE
Add whitelist for modes

### DIFF
--- a/src/departure/index.js
+++ b/src/departure/index.js
@@ -30,6 +30,7 @@ type GetDeparturesParams = {
     timeRange?: number,
     whiteListedLines?: Array<string>,
     whiteListedAuthorities?: Array<string>,
+    whiteListedModes?: Array<string>,
 }
 
 export function getDeparturesFromStopPlaces(
@@ -43,6 +44,7 @@ export function getDeparturesFromStopPlaces(
         includeNonBoarding = false,
         whiteListedLines,
         whiteListedAuthorities,
+        whiteListedModes,
         ...rest
     } = params
 
@@ -54,6 +56,7 @@ export function getDeparturesFromStopPlaces(
         limit,
         whiteListedLines,
         whiteListedAuthorities,
+        whiteListedModes,
         ...rest,
     }
 

--- a/src/departure/query.js
+++ b/src/departure/query.js
@@ -38,6 +38,7 @@ export const getDeparturesFromStopPlacesQuery = {
             omitNonBoarding: 'Boolean!',
             whiteListedLines: '[String!]',
             whiteListedAuthorities: '[String!]',
+            whiteListedModes: '[Mode]',
         },
         stopPlaces: {
             __args: {
@@ -54,6 +55,7 @@ export const getDeparturesFromStopPlacesQuery = {
                         lines: new VariableType('whiteListedLines'),
                         authorities: new VariableType('whiteListedAuthorities'),
                     },
+                    whiteListedModes: new VariableType('whiteListedModes'),
                 },
                 ...departureFields,
             },


### PR DESCRIPTION
You can now send the param `whiteListedModes` to `getDeparturesFromStopPlace` and `getDeparturesFromStopPlaces`.