### PR TITLE
npm audit fix + .idea/ i gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 lib/
 .DS_Store
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1892,9 +1892,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.0.0"


### PR DESCRIPTION
Samme PR som jeg gjorde på next-branchen.

Github klager på at eslint-tools har et kritisk sikkerhetshull: https://github.com/mysticatea/eslint-utils/security/advisories/GHSA-3gx7-xhv7-5mx3

Jeg kjørte `npm audit fix` og feilen ble rettet.

I tillegg: `./ideal` i gitignore.