### PR TITLE
Optional `description` field for Authority

### DIFF
--- a/flow-types/Authority.js
+++ b/flow-types/Authority.js
@@ -5,4 +5,5 @@ export type Authority = {
     name: string,
     codeSpace: string,
     url?: string,
+    county?: string,
 }

--- a/flow-types/Authority.js
+++ b/flow-types/Authority.js
@@ -5,5 +5,5 @@ export type Authority = {
     name: string,
     codeSpace: string,
     url?: string,
-    county?: string,
+    description?: string,
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,7 @@ export interface Authority {
     name: string;
     codeSpace: string;
     url?: string;
-    county?: string;
+    description?: string;
 }
 
 export interface Operator {

--- a/index.d.ts
+++ b/index.d.ts
@@ -151,8 +151,9 @@ export interface Location {
 export interface Authority {
     id: string;
     name: string;
-    codeSpace: string,
+    codeSpace: string;
     url?: string;
+    county?: string;
 }
 
 export interface Operator {

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -154,7 +154,7 @@ type $entur$sdk$Authority = {
     name: string,
     codeSpace: string,
     url?: string,
-    county?: string,
+    description?: string,
 }
 
 type $entur$sdk$Operator = {

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -154,6 +154,7 @@ type $entur$sdk$Authority = {
     name: string,
     codeSpace: string,
     url?: string,
+    county?: string,
 }
 
 type $entur$sdk$Operator = {


### PR DESCRIPTION
### + county

County field will be mapped in from `organisation`. Not present in OTP response.