### PR TITLE
Add getBikeRentalStations method

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Miss anything? Found a bug? File an [issue](https://github.com/entur/sdk/issues/
     * [getDeparturesFromQuays](#getdeparturesfromquays)
     * [getDeparturesBetweenStopPlaces](#getdeparturesbetweenstopplaces)
     * [getBikeRentalStation](#getbikerentalstation)
+    * [getBikeRentalStations](#getbikerentalstations)
     * [getBikeRentalStationsByPosition](#getbikerentalstationsbyposition)
     * [getStopPlace](#getstopplace)
     * [getStopPlaces](#getstopplaces)
@@ -299,6 +300,21 @@ Types: [BikeRentalStation](flow-types/BikeRentalStation.js)
 
 ##### stationId (`string`)
 The ID of the bike rental station you are interested in. The method will return a Promise which will resolve to an object of type [BikeRentalStation](flow-types/BikeRentalStation.js).
+
+### getBikeRentalStations
+
+```javascript
+(stationIds: Array<string>) => Promise<Array<BikeRentalStation>>
+```
+
+Types: [BikeRentalStation](flow-types/BikeRentalStation.js)
+
+`getBikeRentalStations` finds multiple bike rental stations according to an array of IDs. The returned array will have the same order as the input array, and may contain undefined values if the corresponding ID didn't produce a result.
+
+#### Parameters
+
+##### stationIds (`Array<string>`)
+The IDs of the bike rental stations you are interested in. The method will return a Promise which will resolve to an array of objects of type [BikeRentalStation](flow-types/BikeRentalStation.js).
 
 ### getBikeRentalStationsByPosition
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -607,6 +607,8 @@ declare class EnturService {
 
   getBikeRentalStation(stationId: string): Promise<BikeRentalStation>;
 
+  getBikeRentalStations(stationIds: Array<string>): Promise<Array<BikeRentalStation | undefined>>;
+
   getBikeRentalStationsByPosition(
     coordinates: Coordinates,
     distance?: number,

--- a/src/bikeRental/query.js
+++ b/src/bikeRental/query.js
@@ -25,6 +25,14 @@ export const getBikeRentalStationQuery = {
     },
 }
 
+export const getBikeRentalStationsQuery = {
+    query: {
+        bikeRentalStations: {
+            ...bikeRentalStationFields,
+        },
+    },
+}
+
 export const getBikeRentalStationsByPositionQuery = {
     query: {
         __variables: {

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -620,6 +620,8 @@ declare module '@entur/sdk' {
 
         getBikeRentalStation(stationId: string): Promise<$entur$sdk$BikeRentalStation>,
 
+        getBikeRentalStations(stationId: Array<string>): Promise<Array<$entur$sdk$BikeRentalStation | void>>,
+
         getBikeRentalStationsByPosition(
             coordinates: $entur$sdk$Coordinates,
             distance?: number

--- a/src/service.js
+++ b/src/service.js
@@ -21,8 +21,8 @@ import {
 } from './stopPlace'
 import {
     getBikeRentalStation,
+    getBikeRentalStations,
     getBikeRentalStationsByPosition,
-    getBikeRentalStationsDEPRECATED,
 } from './bikeRental'
 import { getFeatures } from './geocoder'
 import { getServiceConfig } from './config'
@@ -70,9 +70,9 @@ class EnturService {
 
     getBikeRentalStation = getBikeRentalStation
 
-    getBikeRentalStationsByPosition = getBikeRentalStationsByPosition
+    getBikeRentalStations = getBikeRentalStations
 
-    getBikeRentalStations = getBikeRentalStationsDEPRECATED
+    getBikeRentalStationsByPosition = getBikeRentalStationsByPosition
 }
 
 export default EnturService


### PR DESCRIPTION
Adds the `getBikeRentalStations` method that takes an array of IDs to get the bike rental stations for. It works very similarly to `getStopPlaces`.

The JourneyPlanner query for `bikeRentalStations` does not take any parameters (yet). So we filter on IDs ourselves. 

Tested by linking it into my own testing repo.

Fixes #87 