### PR TITLE
Handle duplicates in forceOrder util

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -84,13 +84,17 @@ export function forceOrder<T>(
     sequence: Array<any>,
     predicate?: (T) => any = item => item,
 ): Array<T | void> {
-    return list.reduce((arr: Array<T | void>, item: T) => {
-        const index = sequence.indexOf(predicate(item))
-        if (index > -1) {
-            // eslint-disable-next-line no-param-reassign
-            arr[index] = item
-        }
+    let queue = [...list]
+    const result = []
 
-        return arr
-    }, new Array(sequence.length).fill(undefined))
+    sequence.forEach((sequenceIdentifier) => {
+        const item = queue.find(t => predicate(t) === sequenceIdentifier)
+        if (item) {
+            result.push(item)
+            queue = queue.filter(q => q !== item)
+        } else {
+            result.push(undefined)
+        }
+    })
+    return result
 }


### PR DESCRIPTION
Dagens `forceOrder` støttar ikkje duplikatar, p.g.a bruken av `indexOf`.

Eksempel på problem:

```
forceOrder([{ id: 1, n: 'A' }, { id: 1, n: 'B' }], [1, 1], ({ id }) => id)
// Resultat: [{ id: 1, n: 'B' }, undefined]
// Forventa: [{ id: 1, n: 'A' }, { id: 1, n: 'B' }]
```

Den første plassen blir overskriven fordi det er to element som har samme første index i sequence.
