### PR TITLE
Departures option: limitPerLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ An optional object of parameters to pass to the query.
 | `departures`             | `number`       | `5`          | The number of departures to return for each stop place. |
 | `includeNonBoarding`     | `boolean`      | `false`      | Whether to include departures that do not accept boarding at given stop place. |
 | `limit`                  | `number`       | `50`         | The maximum number of departures to fetch. |
+| `limitPerLine`           | `number`       | No limit     | The maximum number of departures to fetch per line and destination display. |
 | `whiteListedLines`       | `Array<string>` | `undefined` | A list of line IDs to include. All others will be excluded. If omitted, all are included. |
 | `whiteListedAuthorities` | `Array<string>` | `undefined` | A list of authority IDs to include. All others will be excluded. If omitted, all are included. |
 | `whiteListedModes`       | `Array<string>` | `undefined` | A list of transport modes to include. All others will be excluded. If omitted, all are included. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -367,6 +367,7 @@ export interface TripPattern {
 export interface GetDeparturesParams {
     includeNonBoarding?: boolean;
     limit?: number;
+    limitPerLine?: number;
     start?: Date;
     timeRange?: number;
     whiteListedLines?: Array<string>;

--- a/src/departure/index.js
+++ b/src/departure/index.js
@@ -26,6 +26,7 @@ import type {
 type GetDeparturesParams = {
     includeNonBoarding?: boolean,
     limit?: number,
+    limitPerLine?: number,
     start?: Date,
     timeRange?: number,
     whiteListedLines?: Array<string>,
@@ -41,6 +42,7 @@ export function getDeparturesFromStopPlaces(
         limit = 50,
         timeRange = 72000,
         start = new Date(),
+        limitPerLine,
         includeNonBoarding = false,
         whiteListedLines,
         whiteListedAuthorities,
@@ -54,6 +56,7 @@ export function getDeparturesFromStopPlaces(
         omitNonBoarding: !includeNonBoarding,
         timeRange,
         limit,
+        limitPerLine,
         whiteListedLines,
         whiteListedAuthorities,
         whiteListedModes,
@@ -90,6 +93,7 @@ export function getDeparturesFromQuays(
 ): Promise<Array<QuayDepartures | void>> {
     const {
         limit = 30,
+        limitPerLine,
         timeRange = 72000,
         includeNonBoarding = false,
         start = new Date(),
@@ -102,6 +106,7 @@ export function getDeparturesFromQuays(
         omitNonBoarding: !includeNonBoarding,
         timeRange,
         limit,
+        limitPerLine,
         ...rest,
     }
     return journeyPlannerQuery(getDeparturesFromQuayQuery, variables, undefined, this.config)

--- a/src/departure/query.js
+++ b/src/departure/query.js
@@ -35,6 +35,7 @@ export const getDeparturesFromStopPlacesQuery = {
             start: 'DateTime!',
             timeRange: 'Int!',
             limit: 'Int!',
+            limitPerLine: 'Int',
             omitNonBoarding: 'Boolean!',
             whiteListedLines: '[String!]',
             whiteListedAuthorities: '[String!]',
@@ -50,6 +51,7 @@ export const getDeparturesFromStopPlacesQuery = {
                     startTime: new VariableType('start'),
                     timeRange: new VariableType('timeRange'),
                     numberOfDepartures: new VariableType('limit'),
+                    numberOfDeparturesPerLineAndDestinationDisplay: new VariableType('limitPerLine'),
                     omitNonBoarding: new VariableType('omitNonBoarding'),
                     whiteListed: {
                         lines: new VariableType('whiteListedLines'),

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -411,6 +411,7 @@ type $entur$sdk$StopPlaceDepartures = {
 type $entur$sdk$GetDeparturesParams = {
     includeNonBoarding?: boolean,
     limit?: number,
+    limitPerLine?: number,
     departures?: number, // deprecated
     timeRange?: number,
     whiteListedLines?: Array<string>,


### PR DESCRIPTION
Uses the `numberOfDeparturesPerLineAndDestinationDisplay` parameter for estimatedCalls in order to limit departures per line.

Should it be called the same as the GraphQL parameter (`numberOfDeparturesPerLineAndDestinationDisplay`)? 