### PR TITLE
expectedDepartureTime, expectedArrivalTime are always defined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -229,8 +229,8 @@ export interface EstimatedCall {
     cancellation: boolean;
     date: string;
     destinationDisplay: DestinationDisplay;
-    expectedArrivalTime?: string; // Only available BEFORE arrival has taken place
-    expectedDepartureTime?: string; // Only available BEFORE departure has taken place
+    expectedArrivalTime: string;
+    expectedDepartureTime: string;
     forAlighting: boolean;
     forBoarding: boolean;
     notices?: Array<Notice>;

--- a/src/fields/EstimatedCall.js
+++ b/src/fields/EstimatedCall.js
@@ -15,8 +15,8 @@ export type EstimatedCall = {|
     destinationDisplay: {
         frontText: string,
     },
-    expectedArrivalTime?: string, // Only available BEFORE arrival has taken place
-    expectedDepartureTime?: string, // Only available BEFORE departure has taken place
+    expectedArrivalTime: string,
+    expectedDepartureTime: string,
     forAlighting: boolean,
     forBoarding: boolean,
     notices?: Array<Notice>,

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -298,8 +298,8 @@ type $entur$sdk$EstimatedCall = {
     cancellation: boolean,
     date: string,
     destinationDisplay: $entur$sdk$DestinationDisplay,
-    expectedArrivalTime?: string, // Only available BEFORE arrival has taken place
-    expectedDepartureTime?: string, // Only available BEFORE departure has taken place
+    expectedArrivalTime: string,
+    expectedDepartureTime: string,
     forAlighting: boolean,
     forBoarding: boolean,
     notices?: Array<$entur$sdk$Notice>,


### PR DESCRIPTION
"Only available BEFORE arrival has taken place"

☝️ This is legacy.