### PR TITLE
Add method getDeparturesForServiceJourney

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,24 @@ The ID of the stop place to get departures _to_.
 | `limit`                  | `number`       | `20`         | The maximum number of departures to fetch. |
 
 
+### getDeparturesForServiceJourney
+
+```javascript
+(id: string, date?: string) => Promise<Array<Departure>>
+```
+
+Types: [Departure](flow-types/Departures.js)
+
+`getDeparturesForServiceJourney` finds departures for a given service journey ID. You can also provide a desired date on the form "YYYY-MM-DD".
+
+#### Parameters
+
+##### id (`string`)
+The ID of the service journey to get departures for.
+
+##### date (`string`) [Optional]
+A date on the form "YYYY-MM-DD" to use if you want the service journey's departures for another date than today.
+
 ### getNearestPlaces
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -574,6 +574,11 @@ declare class EnturService {
       params?: GetDeparturesBetweenStopPlacesParams,
   ): Promise<Departure[]>;
 
+  getDeparturesForServiceJourney(
+      id: string,
+      date?: string,
+  ): Promise<Departure[]>;
+
   getNearestPlaces(
       coordinates: Coordinates,
       params?: {

--- a/src/departure/index.js
+++ b/src/departure/index.js
@@ -12,6 +12,7 @@ import {
     getDeparturesFromStopPlacesQuery,
     getDeparturesFromQuayQuery,
     getDeparturesBetweenStopPlacesQuery,
+    getDeparturesForServiceJourneyQuery,
 } from './query'
 
 import {
@@ -165,6 +166,26 @@ export function getDeparturesBetweenStopPlaces(
 
                 return legToDepartureMapper(leg)
             }).filter(Boolean)
+        })
+}
+
+export function getDeparturesForServiceJourney(
+    id: string,
+    date?: string,
+): Promise<Array<EstimatedCall>> {
+    const variables = {
+        id,
+        date,
+    }
+
+    return journeyPlannerQuery(
+        getDeparturesForServiceJourneyQuery,
+        variables,
+        undefined,
+        this.config,
+    )
+        .then((data: Object) => {
+            return (data?.serviceJourney?.estimatedCalls || []).map(destinationMapper)
         })
 }
 

--- a/src/departure/query.js
+++ b/src/departure/query.js
@@ -92,9 +92,28 @@ export const getDeparturesBetweenStopPlacesQuery = {
                 wheelchair: false,
                 maximumTransfers: 0,
             },
-
             tripPatterns: {
                 legs: legFields,
+            },
+        },
+    },
+}
+
+export const getDeparturesForServiceJourneyQuery = {
+    query: {
+        __variables: {
+            id: 'String!',
+            date: 'Date',
+        },
+        serviceJourney: {
+            __args: {
+                id: new VariableType('id'),
+            },
+            estimatedCalls: {
+                __args: {
+                    date: new VariableType('date'),
+                },
+                ...estimatedCallFields,
             },
         },
     },

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -588,6 +588,11 @@ declare module '@entur/sdk' {
             params?: $entur$sdk$GetDeparturesBetweenStopPlacesParams,
         ): Promise<Array<$entur$sdk$Departure>>,
 
+        getDeparturesForServiceJourney(
+            id: string,
+            date?: string,
+        ): Promise<Array<$entur$sdk$Departure>>,
+
         getNearestPlaces(
             coordinates: $entur$sdk$Coordinates,
             params?: {

--- a/src/service.js
+++ b/src/service.js
@@ -11,6 +11,7 @@ import {
     getDeparturesFromStopPlaces,
     getDeparturesFromQuays,
     getDeparturesBetweenStopPlaces,
+    getDeparturesForServiceJourney,
     getStopPlaceDeparturesDEPRECATED,
 } from './departure'
 
@@ -63,6 +64,8 @@ class EnturService {
     getDeparturesFromQuays = getDeparturesFromQuays
 
     getDeparturesBetweenStopPlaces = getDeparturesBetweenStopPlaces
+
+    getDeparturesForServiceJourney = getDeparturesForServiceJourney
 
     getNearestPlaces = getNearestPlaces
 


### PR DESCRIPTION
`getDeparturesForServiceJourney` finds departures for a given service journey ID. You can also provide a desired date on the form "YYYY-MM-DD".

Useful for "stops on line" functionality.