### PR TITLE
Add missing transport modes in TransportMode type

### DIFF
--- a/flow-types/Mode.js
+++ b/flow-types/Mode.js
@@ -2,12 +2,15 @@
 export type TransportMode =
     | 'air'
     | 'bus'
-    | 'water'
-    | 'rail'
-    | 'metro'
-    | 'tram'
+    | 'cableway'
     | 'coach'
-    | 'car'
+    | 'funicular'
+    | 'lift'
+    | 'metro'
+    | 'rail'
+    | 'tram'
+    | 'unknown'
+    | 'water'
 
 // All valid values for the "mode" parameter to JourneyPlanner
 export type QueryMode =

--- a/index.d.ts
+++ b/index.d.ts
@@ -185,14 +185,17 @@ export interface Place {
 }
 
 export type TransportMode =
-    | "air"
-    | "bus"
-    | "water"
-    | "rail"
-    | "metro"
-    | "tram"
-    | "coach"
-    | "car"
+    | 'air'
+    | 'bus'
+    | 'cableway'
+    | 'coach'
+    | 'funicular'
+    | 'lift'
+    | 'metro'
+    | 'rail'
+    | 'tram'
+    | 'unknown'
+    | 'water'
 
 // All valid values for the "mode" parameter to JourneyPlanner
 export type QueryMode =

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -198,12 +198,15 @@ type $entur$sdk$Place = {
 type $entur$sdk$TransportMode =
     | 'air'
     | 'bus'
-    | 'water'
-    | 'rail'
-    | 'metro'
-    | 'tram'
+    | 'cableway'
     | 'coach'
-    | 'car'
+    | 'funicular'
+    | 'lift'
+    | 'metro'
+    | 'rail'
+    | 'tram'
+    | 'unknown'
+    | 'water'
 
 // All valid values for the "mode" parameter to JourneyPlanner
  type $entur$sdk$QueryMode =


### PR DESCRIPTION
Adds `funicular`, `cableway` and `unknown` to make union type complete.