### PR TITLE
Move from and to params into GetTripPatternsParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The wanted time of departure. Can be anything that is parseable by `new Date()`.
 ### getTripPatterns
 
 ```javascript
-(from: Location, to: Location, params?: GetTripPatternsParams, ignoreFields?: Array<string>) => Promise<Array<TripPattern>>
+(params: GetTripPatternsParams, ignoreFields?: Array<string>) => Promise<Array<TripPattern>>
 ```
 
 Types: [TripPattern](flow-types/TripPattern.js)
@@ -96,17 +96,13 @@ If you are going to do a huge amount of different searches at the same time, con
 
 #### Parameters
 
-##### from (`Location`)
-The location to search for travels from.
-
-##### to (`Location`)
-The destination location to search for travels to.
-
-##### params (`GetTripPatternsParams`) [Optional]
+##### params (`GetTripPatternsParams`)
 An object of search parameters.
 
 | Key                         | Type               | Default   | Description |
 |:----------------------------|:-------------------|:----------|:------------|
+| `from`                      | `Location`         |          | The location to search for travels from. |
+| `to`                        | `Location`         |          | The destination location to search for travels to. |
 | `allowBikeRental`           | `boolean`          | `false` | Is bike rental allowed? |
 | `arriveBy`                  | `boolean`          | `false` | Depart by `searchDate`, or arrive by `searchDate` |
 | `limit`                     | `number`           | `5`      | Limit result to this number of trip patterns |
@@ -145,17 +141,17 @@ Default:
 ```javascript
 service.getTripPatterns(
     {
-        name: 'Ryllikvegen, Lillehammer',
-        coordinates: {
-            latitude: 61.102848368937416,
-            longitude: 10.51613308426234
+        from: {
+            name: 'Ryllikvegen, Lillehammer',
+            coordinates: {
+                latitude: 61.102848368937416,
+                longitude: 10.51613308426234
+            },
         },
-    },
-    {
-        place: 'NSR:StopPlace:337',
-        name: 'Oslo S, Oslo'
-    },
-    {
+        to: {
+            place: 'NSR:StopPlace:337',
+            name: 'Oslo S, Oslo'
+        },
         searchDate: new Date(),
     }
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -358,6 +358,8 @@ export interface TransportSubmodeParam {
 }
 
 export interface GetTripPatternsParams {
+    from: Location;
+    to: Location;
     allowBikeRental?: boolean;
     arriveBy?: boolean;
     limit?: number;
@@ -554,9 +556,7 @@ declare class EnturService {
   ): Promise<Feature[]>;
 
   getTripPatterns(
-      from: Location,
-      to: Location,
-      params?: GetTripPatternsParams,
+      params: GetTripPatternsParams,
       ignoreFields?: Array<string>,
   ): Promise<TripPattern[]>;
 

--- a/src/libdef.flow.js
+++ b/src/libdef.flow.js
@@ -372,6 +372,8 @@ type $entur$sdk$TransportSubmodeParam = {
 }
 
 type $entur$sdk$GetTripPatternsParams = {
+    from: $entur$sdk$Location,
+    to: $entur$sdk$Location,
     allowBikeRental?: boolean,
     arriveBy?: boolean,
     limit?: number,
@@ -568,9 +570,7 @@ declare module '@entur/sdk' {
         ): Promise<Array<$entur$sdk$Feature>>,
 
         getTripPatterns(
-            from: $entur$sdk$Location,
-            to: $entur$sdk$Location,
-            params?: $entur$sdk$GetTripPatternsParams,
+            params: $entur$sdk$GetTripPatternsParams,
             ignoreFields?: Array<string>,
         ): Promise<Array<$entur$sdk$TripPattern>>,
 

--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -37,6 +37,8 @@ type TransportSubmodeParam = {
 }
 
 export type GetTripPatternsParams = {
+    from: Location,
+    to: Location,
     allowBikeRental?: boolean,
     arriveBy?: boolean,
     limit?: number,
@@ -66,12 +68,12 @@ const DEFAULT_GET_TRIP_PATTERN_IGNORE_FIELDS = [
 ]
 
 export function getTripPatterns(
-    from: Location,
-    to: Location,
-    params?: GetTripPatternsParams = {},
+    params: GetTripPatternsParams = {},
     ignoreFields?: Array<string> = DEFAULT_GET_TRIP_PATTERN_IGNORE_FIELDS,
 ): Promise<Array<TripPattern>> {
     const {
+        from,
+        to,
         searchDate = new Date(),
         arriveBy = false,
         modes = [FOOT, BUS, TRAM, RAIL, METRO, WATER, AIR],


### PR DESCRIPTION
* This makes GetTripPatternsParams completely represent a search.
* It's easier to use getTripPatterns with the throttler util.
* It's the same API as in v0
* Calls are more readable since it says "from" and "to"