### PR TITLE
Fix async findtrips

### DIFF
--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -34,12 +34,12 @@ type TripPattern = {
     id?: string,
     legs: Array<Leg>,
     startTime: string,
-    walkDistance: number
+    walkDistance: number,
 }
 
 type TransportSubmodeParam = {
     transportMode: TransportMode,
-    transportSubmodes: Array<TransportSubmode>
+    transportSubmodes: Array<TransportSubmode>,
 }
 
 type InputBanned = {|
@@ -48,13 +48,13 @@ type InputBanned = {|
     organisations?: Array<string>,
     quays?: Array<string>,
     quaysHard?: Array<string>,
-    serviceJourneys?: Array<string>
+    serviceJourneys?: Array<string>,
 |}
 
 type InputWhiteListed = {|
     lines?: Array<string>,
     authorities?: Array<string>,
-    organisations?: Array<string>
+    organisations?: Array<string>,
 |}
 
 export type GetTripPatternsParams = {
@@ -71,7 +71,7 @@ export type GetTripPatternsParams = {
     walkSpeed?: number,
     wheelchairAccessible?: boolean,
     banned?: InputBanned,
-    whiteListed?: InputWhiteListed
+    whiteListed?: InputWhiteListed,
 }
 
 function getTripPatternsVariables(


### PR DESCRIPTION
findTrips was declared async. This caused issues with babel's regenerator runtime not being available after transpiling. 

This change makes the function align with the rest of the API by not using async/await.
