### PR TITLE
Fix async/await in browser and fix findTrips

### DIFF
--- a/docs/travel/findTrips.mdx
+++ b/docs/travel/findTrips.mdx
@@ -34,22 +34,14 @@ const service = new EnturService({
     clientName: 'awesomecompany-awesomeapp'
 })
 
-async function printTripPatterns() {
-    const [fromFeature] = await service.getFeatures('Ryllikvegen, Lillehammer')
-    const [toFeature] = await service.getFeatures('Oslo S')
-
-    if (!fromFeature || !toFeature) {
-        return
+async function findSomeTrips() {
+    try {
+        const trips = await service.findTrips('Oslo S', 'Bergen stasjon')
+        console.log(trips);
+    } catch (error) {
+        console.error(error)
     }
-
-    const tripPatterns = await service.getTripPatterns({
-        searchDate: new Date(),
-        from: convertFeatureToLocation(fromFeature),
-        to: convertFeatureToLocation(toFeature),
-    })
-
-    console.log(tripPatterns)
 }
 
-printTripPatterns()
+findSomeTrips()
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -21211,8 +21211,7 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "node-fetch": "^2.6.0",
     "promise-throttle": "^1.0.1",
     "qs": "^6.9.1",
+    "regenerator-runtime": "^0.13.3",
     "turf-linestring": "^1.0.2",
     "turf-point": "^2.0.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 // @flow
 
+import 'regenerator-runtime/runtime'
+
 import EnturService from './service'
 
 export {

--- a/src/trip/index.js
+++ b/src/trip/index.js
@@ -152,9 +152,9 @@ export async function findTrips(
         throw new Error(`Entur SDK: Could not find any locations matching <to> argument "${to}"`)
     }
 
-    return this.getTripPatterns(
-        convertFeatureToLocation(fromFeatures[0]),
-        convertFeatureToLocation(toFeatures[0]),
+    return this.getTripPatterns({
+        from: convertFeatureToLocation(fromFeatures[0]),
+        to: convertFeatureToLocation(toFeatures[0]),
         searchDate,
-    )
+    })
 }


### PR DESCRIPTION
* Uses `regenerator-runtime` in order to run transpiled async/await statements in browser.
* Fixes the arguments passed to `getTripPatterns` from `findTrips`.
* Fixes example for `findTrips`.