### PR TITLE
Improve error message if wrong type passed to functions

### DIFF
--- a/src/bikeRental/index.ts
+++ b/src/bikeRental/index.ts
@@ -32,7 +32,7 @@ export function createGetBikeRentalStations(argConfig: ArgumentConfig) {
         stationIds: Array<string>,
     ): Promise<Array<BikeRentalStation | void>> {
         if (!stationIds || !Array.isArray(stationIds)) {
-            throw new Error(`getBikeRentalStations takes an an array of strings, but got ${typeof stationIds}`)
+            throw new Error(`getBikeRentalStations takes an array of strings, but got ${typeof stationIds}`)
         }
 
         if (stationIds.length === 0) {

--- a/src/departure/index.ts
+++ b/src/departure/index.ts
@@ -47,6 +47,14 @@ export function createGetDeparturesFromStopPlaces(argConfig: ArgumentConfig) {
         stopPlaceIds: Array<string>,
         params: GetDeparturesParams = {},
     ): Promise<Array<DeparturesById | void>> {
+        if (!stopPlaceIds || !Array.isArray(stopPlaceIds)) {
+            throw new Error(`getDeparturesFromStopPlaces takes an an array of strings, but got ${typeof stopPlaceIds}`)
+        }
+
+        if (stopPlaceIds.length === 0) {
+            return Promise.resolve([])
+        }
+
         const {
             limit = 50,
             timeRange = 72000,
@@ -113,6 +121,14 @@ export function createGetDeparturesFromQuays(argConfig: ArgumentConfig) {
         quayIds: Array<string>,
         params: GetDeparturesParams = {},
     ): Promise<Array<DeparturesById | void>> {
+        if (!quayIds || !Array.isArray(quayIds)) {
+            throw new Error(`getDeparturesFromQuays takes an an array of strings, but got ${typeof quayIds}`)
+        }
+
+        if (quayIds.length === 0) {
+            return Promise.resolve([])
+        }
+
         const {
             limit = 30,
             limitPerLine,

--- a/src/departure/index.ts
+++ b/src/departure/index.ts
@@ -48,7 +48,7 @@ export function createGetDeparturesFromStopPlaces(argConfig: ArgumentConfig) {
         params: GetDeparturesParams = {},
     ): Promise<Array<DeparturesById | void>> {
         if (!Array.isArray(stopPlaceIds)) {
-            throw new Error(`getDeparturesFromStopPlaces takes an an array of strings, but got ${typeof stopPlaceIds}`)
+            throw new Error(`getDeparturesFromStopPlaces takes an array of strings, but got ${typeof stopPlaceIds}`)
         }
 
         if (stopPlaceIds.length === 0) {
@@ -122,7 +122,7 @@ export function createGetDeparturesFromQuays(argConfig: ArgumentConfig) {
         params: GetDeparturesParams = {},
     ): Promise<Array<DeparturesById | void>> {
         if (!Array.isArray(quayIds)) {
-            throw new Error(`getDeparturesFromQuays takes an an array of strings, but got ${typeof quayIds}`)
+            throw new Error(`getDeparturesFromQuays takes an array of strings, but got ${typeof quayIds}`)
         }
 
         if (quayIds.length === 0) {

--- a/src/departure/index.ts
+++ b/src/departure/index.ts
@@ -47,7 +47,7 @@ export function createGetDeparturesFromStopPlaces(argConfig: ArgumentConfig) {
         stopPlaceIds: Array<string>,
         params: GetDeparturesParams = {},
     ): Promise<Array<DeparturesById | void>> {
-        if (!stopPlaceIds || !Array.isArray(stopPlaceIds)) {
+        if (!Array.isArray(stopPlaceIds)) {
             throw new Error(`getDeparturesFromStopPlaces takes an an array of strings, but got ${typeof stopPlaceIds}`)
         }
 
@@ -121,7 +121,7 @@ export function createGetDeparturesFromQuays(argConfig: ArgumentConfig) {
         quayIds: Array<string>,
         params: GetDeparturesParams = {},
     ): Promise<Array<DeparturesById | void>> {
-        if (!quayIds || !Array.isArray(quayIds)) {
+        if (!Array.isArray(quayIds)) {
             throw new Error(`getDeparturesFromQuays takes an an array of strings, but got ${typeof quayIds}`)
         }
 

--- a/src/stopPlace/index.ts
+++ b/src/stopPlace/index.ts
@@ -46,7 +46,7 @@ export function createGetStopPlaces(argConfig: ArgumentConfig) {
         params: StopPlaceParams = {},
     ): Promise<Array<StopPlaceDetails | void>> {
         if (!Array.isArray(stopPlaceIds)) {
-            throw new Error(`getStopPlaces takes an an array of strings, but got ${typeof stopPlaceIds}`)
+            throw new Error(`getStopPlaces takes an array of strings, but got ${typeof stopPlaceIds}`)
         }
 
         if (stopPlaceIds.length === 0) {

--- a/src/stopPlace/index.ts
+++ b/src/stopPlace/index.ts
@@ -45,7 +45,7 @@ export function createGetStopPlaces(argConfig: ArgumentConfig) {
         stopPlaceIds: Array<string>,
         params: StopPlaceParams = {},
     ): Promise<Array<StopPlaceDetails | void>> {
-        if (!stopPlaceIds || !Array.isArray(stopPlaceIds)) {
+        if (!Array.isArray(stopPlaceIds)) {
             throw new Error(`getStopPlaces takes an an array of strings, but got ${typeof stopPlaceIds}`)
         }
 


### PR DESCRIPTION
Improve error message if wrong type passed to getDeparturesFromStopPlaces, getDeparturesFromQuays.

If you call `getDeparturesFromStopPlaces` today with, say, a string, you get the message `sequence.forEach is not a function`, which is a bad error message.