### PR TITLE
getDeparturesFromQuayQuery: includeCancelledTrips is required

### DIFF
--- a/src/departure/query.ts
+++ b/src/departure/query.ts
@@ -51,7 +51,7 @@ query(
     $timeRange: Int!,
     $limit: Int!,
     $omitNonBoarding: Boolean!,
-    $includeCancelledTrips: Boolean
+    $includeCancelledTrips: Boolean!
 ) {
     quays(ids: $ids) {
         id


### PR DESCRIPTION
Query fails with 

`
{
  "errors": [
    {
      "path": null,
      "errorType": "ValidationError",
      "locations": [
        {
          "line": 4,
          "column": 148
        }
      ],
      "message": "Validation error of type VariableTypeMismatch: Variable type 'Boolean' doesn't match expected type 'Boolean!' @ 'quays/estimatedCalls'"
    }
  ]
}
`

otherwise