### PR TITLE
Use a http.Agent with support for keepAlive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4587,6 +4587,31 @@
       "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
       "dev": true
     },
+    "agentkeepalive": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.0.tgz",
+      "integrity": "sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -9105,8 +9130,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "des.js": {
       "version": "1.0.1",
@@ -17208,6 +17232,14 @@
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "humanize-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-2.1.0.tgz",
@@ -20090,8 +20122,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@turf/bbox": "^6.0.1",
     "@turf/destination": "^6.0.1",
     "@turf/helpers": "^6.1.4",
+    "agentkeepalive": "^4.1.0",
     "clean-deep": "^3.2.0",
     "node-fetch": "^2.6.0",
     "promise-throttle": "^1.0.1",

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,3 +1,12 @@
-import nodeFetch from 'node-fetch'
+import nodeFetch, { RequestInit, RequestInfo } from "node-fetch";
+import { HttpsAgent as Agent } from "agentkeepalive";
 
-export default nodeFetch
+const agent = new Agent({
+    keepAlive: true
+});
+
+export default (url: RequestInfo, init?: RequestInit) =>
+    nodeFetch(url, {
+        agent,
+        ...init
+    });


### PR DESCRIPTION
The current fetch implementation used by this library (when running on Node) uses the global http Agent which has keepAlive set to false.

Proposing a change to either:
- Allow injecting a custom http.Agent (unclear how to do this, as the dependencies are hardwired)
- Use a default agent with keepAlive set to true and sane timeouts.

Benchmarks on our own BFF shows that for the geocoder endpoints, keepAlive improves latency by ~50% (grain of salt, etc.) which is quite a big deal in a typical "autocomplete" scenario. 