### PR TITLE
Throw error if no base data in departures calls

### DIFF
--- a/src/departure/index.ts
+++ b/src/departure/index.ts
@@ -85,7 +85,7 @@ export function createGetDeparturesFromStopPlaces(argConfig: ArgumentConfig) {
         return journeyPlannerQuery<{ stopPlaces?: Array<{ id: string; estimatedCalls: EstimatedCall[] }> }>(getDeparturesFromStopPlacesQuery, variables, config)
             .then((data) => {
                 if (!data?.stopPlaces) {
-                    return []
+                    throw new Error(`Missing data: getDeparturesFromStopPlaces received no data from the API.`)
                 }
 
                 return data.stopPlaces.map(({ estimatedCalls, ...stopPlace }) => ({
@@ -156,7 +156,7 @@ export function createGetDeparturesFromQuays(argConfig: ArgumentConfig) {
         )
             .then((data) => {
                 if (!data || !data?.quays) {
-                    return []
+                    throw new Error(`Missing data: getDeparturesFromQuays received no data from the API.`)
                 }
 
                 return data.quays.map(({ estimatedCalls, ...stopPlace }) => ({


### PR DESCRIPTION
In `getDeparturesFromStopPlaces` and `getDeparturesFromQuays` we say we guarantee that the resulting array is the same length as the input IDs array. This is not true if we return an empty array!

We could return a list of undefined values (`[undefined, undefined, ..., undefined]`) but I think it's better to just through an error with an understandable message.