### PR TITLE
Allow passing custom fetch implementation to config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,71 +3,73 @@
  */
 
 export interface Config {
-    clientName: string;
+    clientName: string
     hosts?: {
-        journeyPlanner?: string;
-        geocoder?: string;
-        nsr?: string;
-    };
-    headers?: { [key: string]: string };
+        journeyPlanner?: string
+        geocoder?: string
+        nsr?: string
+    }
+    headers?: { [key: string]: string }
+    fetch?: (url: string, init?: Record<string, any>) => Promise<any>
 }
 
 export interface OverrideConfig {
-    clientName?: string;
+    clientName?: string
     hosts?: {
-        journeyPlanner?: string;
-        geocoder?: string;
-        nsr?: string;
-    };
-    headers?: { [key: string]: string };
+        journeyPlanner?: string
+        geocoder?: string
+        nsr?: string
+    }
+    headers?: { [key: string]: string }
+    fetch?: (url: string, init?: Record<string, any>) => Promise<any>
 }
 
 export interface Coordinates {
-    latitude: number;
-    longitude: number;
+    latitude: number
+    longitude: number
 }
 
 export interface MultilingualString {
-    lang: 'eng' | 'nob' | 'nno';
-    language?: 'en' | 'nb' | 'nn' | 'no';
-    value: string;
+    lang: 'eng' | 'nob' | 'nno'
+    language?: 'en' | 'nb' | 'nn' | 'no'
+    value: string
 }
 
 export interface Notice {
-    text: string;
+    text: string
 }
 
-export type ReportType = 'general' | 'incident' | null;
+export type ReportType = 'general' | 'incident' | null
 
 export interface ServiceConfig {
-    clientName: string;
+    clientName: string
     hosts: {
-        journeyPlanner: string;
-        geocoder: string;
-        nsr: string;
-    };
-    headers: { [key: string]: string };
+        journeyPlanner: string
+        geocoder: string
+        nsr: string
+    }
+    headers: { [key: string]: string }
 }
 
 interface ValidityPeriod {
-    startTime: string;
-    endTime: string;
+    startTime: string
+    endTime: string
 }
 
 interface InfoLink {
-    uri: string;
-    label: string;
+    uri: string
+    label: string
 }
 
 export interface Situation {
-    situationNumber: string;
-    summary: Array<MultilingualString>;
-    description: Array<MultilingualString>;
-    detail: Array<MultilingualString>;
-    lines: Array<Line>;
-    validityPeriod: ValidityPeriod;
-    reportType: ReportType;
-    infoLinks: Array<InfoLink>;
+    situationNumber: string
+    summary: Array<MultilingualString>
+    description: Array<MultilingualString>
+    detail: Array<MultilingualString>
+    lines: Array<Line>
+    validityPeriod: ValidityPeriod
+    reportType: ReportType
+    infoLinks: Array<InfoLink>
 }
 
 /**
@@ -75,13 +77,13 @@ export interface Situation {
  */
 
 export interface BikeRentalStation {
-    id: string;
-    name: string;
-    bikesAvailable?: number;
-    spacesAvailable?: number;
-    longitude: number;
-    latitude: number;
-    networks: Array<string>;
+    id: string
+    name: string
+    bikesAvailable?: number
+    spacesAvailable?: number
+    longitude: number
+    latitude: number
+    networks: Array<string>
 }
 
 /**
@@ -108,57 +110,57 @@ export type Category =
     | 'Vegadresse'
     | 'street'
     | 'tettsteddel'
-    | 'bydel';
+    | 'bydel'
 
 export interface GetFeaturesParams {
-    'boundary.rect.min_lon'?: number;
-    'boundary.rect.max_lon'?: number;
-    'boundary.rect.min_lat'?: number;
-    'boundary.rect.max_lat'?: number;
-    'boundary.country'?: string;
-    sources?: Array<string>;
-    layers?: Array<string>;
-    limit?: number;
+    'boundary.rect.min_lon'?: number
+    'boundary.rect.max_lon'?: number
+    'boundary.rect.min_lat'?: number
+    'boundary.rect.max_lat'?: number
+    'boundary.country'?: string
+    sources?: Array<string>
+    layers?: Array<string>
+    limit?: number
 }
 
 export interface GetFeaturesReverseParam {
-    radius?: number;
-    size?: number;
-    layers?: Array<string>;
+    radius?: number
+    size?: number
+    layers?: Array<string>
 }
 
 export interface Feature {
     geometry: {
-        coordinates: [number, number]; // longitude, latitude
-        type: 'Point';
-    };
+        coordinates: [number, number] // longitude, latitude
+        type: 'Point'
+    }
     properties: {
-        id: string;
-        name: string;
-        label?: string;
-        borough: string;
-        accuracy: 'point';
-        layer: 'venue' | 'address';
-        borough_gid: string;
-        category: Array<Category>;
-        country_gid: string;
-        county: string;
-        county_gid: string;
-        gid: string;
-        housenumber?: string;
-        locality: string;
-        locality_gid: string;
-        postalcode: string;
-        source: string;
-        source_id: string;
-        street: string;
-    };
+        id: string
+        name: string
+        label?: string
+        borough: string
+        accuracy: 'point'
+        layer: 'venue' | 'address'
+        borough_gid: string
+        category: Array<Category>
+        country_gid: string
+        county: string
+        county_gid: string
+        gid: string
+        housenumber?: string
+        locality: string
+        locality_gid: string
+        postalcode: string
+        source: string
+        source_id: string
+        street: string
+    }
 }
 
 export interface Location {
-    name?: string;
-    place?: string;
-    coordinates?: Coordinates;
+    name?: string
+    place?: string
+    coordinates?: Coordinates
 }
 
 /**
@@ -166,43 +168,43 @@ export interface Location {
  */
 
 export interface Authority {
-    id: string;
-    name: string;
-    codeSpace: string;
-    url?: string;
-    description?: string;
+    id: string
+    name: string
+    codeSpace: string
+    url?: string
+    description?: string
 }
 
 export interface Operator {
-    id: string;
-    name: string;
-    url?: string;
+    id: string
+    name: string
+    url?: string
 }
 
 export interface StopPlace {
-    description?: string;
-    id: string;
-    name: string;
+    description?: string
+    id: string
+    name: string
     tariffZones?: Array<{
-        id: string;
-    }>;
+        id: string
+    }>
 }
 
 export interface Quay {
-    id: string;
-    name: string;
-    description: string;
-    publicCode: string;
-    situations: Array<Situation>;
-    stopPlace: StopPlace;
+    id: string
+    name: string
+    description: string
+    publicCode: string
+    situations: Array<Situation>
+    stopPlace: StopPlace
 }
 
 export interface Place {
-    latitude: number;
-    longitude: number;
-    name?: string;
-    quay?: Quay;
-    bikeRentalStation?: BikeRentalStation;
+    latitude: number
+    longitude: number
+    name?: string
+    quay?: Quay
+    bikeRentalStation?: BikeRentalStation
 }
 
 export type TransportMode =
@@ -216,7 +218,7 @@ export type TransportMode =
     | 'rail'
     | 'tram'
     | 'unknown'
-    | 'water';
+    | 'water'
 
 // All valid values for the 'mode' parameter to JourneyPlanner
 export type QueryMode =
@@ -236,9 +238,9 @@ export type QueryMode =
     | 'rail'
     | 'tram'
     | 'transit'
-    | 'water';
+    | 'water'
 
-export type LegMode = TransportMode | 'bicycle' | 'car' | 'foot';
+export type LegMode = TransportMode | 'bicycle' | 'car' | 'foot'
 
 export type TransportSubmode =
     | 'localBus'
@@ -275,64 +277,64 @@ export type TransportSubmode =
     | 'domesticFlight'
     | 'helicopterService'
     | 'telecabin'
-    | 'funicular';
+    | 'funicular'
 
 export interface DestinationDisplay {
-    frontText: string;
+    frontText: string
 }
 
 export interface EstimatedCall {
-    actualArrivalTime?: string; // Only available AFTER arrival has taken place
-    actualDepartureTime?: string; // Only available AFTER departure has taken place
-    aimedArrivalTime: string;
-    aimedDepartureTime: string;
-    cancellation: boolean;
-    date: string;
-    destinationDisplay: DestinationDisplay;
-    expectedArrivalTime: string;
-    expectedDepartureTime: string;
-    forAlighting: boolean;
-    forBoarding: boolean;
-    notices?: Array<Notice>;
-    quay?: Quay;
-    realtime: boolean;
-    requestStop: boolean;
-    serviceJourney: ServiceJourney;
-    situations: Array<Situation>;
+    actualArrivalTime?: string // Only available AFTER arrival has taken place
+    actualDepartureTime?: string // Only available AFTER departure has taken place
+    aimedArrivalTime: string
+    aimedDepartureTime: string
+    cancellation: boolean
+    date: string
+    destinationDisplay: DestinationDisplay
+    expectedArrivalTime: string
+    expectedDepartureTime: string
+    forAlighting: boolean
+    forBoarding: boolean
+    notices?: Array<Notice>
+    quay?: Quay
+    realtime: boolean
+    requestStop: boolean
+    serviceJourney: ServiceJourney
+    situations: Array<Situation>
 }
 
-export type IntermediateEstimatedCall = EstimatedCall;
+export type IntermediateEstimatedCall = EstimatedCall
 
-export type Departure = EstimatedCall;
+export type Departure = EstimatedCall
 
-export type BookingMethod = 'callOffice' | 'online';
+export type BookingMethod = 'callOffice' | 'online'
 
 export interface BookingContact {
-    phone: string;
-    url: string;
+    phone: string
+    url: string
 }
 
 export interface BookingArrangement {
-    bookingAccess: boolean;
-    bookingContact: BookingContact;
-    latestBookingTime: string;
-    bookingMethods?: Array<BookingMethod>;
-    bookWhen?: string;
-    minimumBookingPeriod?: string;
-    bookingNote?: string;
-    buyWhen: string;
+    bookingAccess: boolean
+    bookingContact: BookingContact
+    latestBookingTime: string
+    bookingMethods?: Array<BookingMethod>
+    bookWhen?: string
+    minimumBookingPeriod?: string
+    bookingNote?: string
+    buyWhen: string
 }
 
 export interface Line {
-    bookingArrangements?: BookingArrangement;
-    description?: string;
-    flexibleLineType?: FlexibleLineType;
-    id: string;
-    name: string;
-    notices?: Array<Notice>;
-    publicCode: string;
-    transportMode: TransportMode;
-    transportSubmode: TransportSubmode;
+    bookingArrangements?: BookingArrangement
+    description?: string
+    flexibleLineType?: FlexibleLineType
+    id: string
+    name: string
+    notices?: Array<Notice>
+    publicCode: string
+    transportMode: TransportMode
+    transportSubmode: TransportSubmode
 }
 
 export type FlexibleLineType =
@@ -345,124 +347,124 @@ export type FlexibleLineType =
     | 'mixedFlexible'
     | 'mixedFlexibleAndFixed'
     | 'fixed'
-    | 'other';
+    | 'other'
 
 export interface Interchange {
-    guaranteed: boolean;
-    staySeated: boolean;
+    guaranteed: boolean
+    staySeated: boolean
 }
 
 export interface PointsOnLink {
-    points: string;
-    length: number;
+    points: string
+    length: number
 }
 
 export interface JourneyPattern {
-    line: Line;
-    notices?: Array<Notice>;
+    line: Line
+    notices?: Array<Notice>
 }
 
 export interface ServiceJourney {
-    id: string;
-    journeyPattern?: JourneyPattern;
-    notices?: Array<Notice>;
-    publicCode?: string;
-    transportSubmode?: TransportSubmode;
+    id: string
+    journeyPattern?: JourneyPattern
+    notices?: Array<Notice>
+    publicCode?: string
+    transportSubmode?: TransportSubmode
 }
 
 export interface Leg {
-    aimedEndTime: string;
-    aimedStartTime: string;
-    authority?: Authority;
-    distance: number;
-    directDuration: number;
-    duration: number;
-    expectedEndTime: string;
-    expectedStartTime: string;
-    fromEstimatedCall?: EstimatedCall;
-    fromPlace: Place;
-    interchangeFrom?: Interchange;
-    interchangeTo?: Interchange;
-    intermediateEstimatedCalls: Array<IntermediateEstimatedCall>;
-    line?: Line;
-    mode: LegMode;
-    notices?: Array<Notice>;
-    operator?: Operator;
-    pointsOnLink: PointsOnLink;
-    realtime: boolean;
-    ride: boolean;
-    rentedBike?: boolean;
-    serviceJourney: ServiceJourney;
-    situations: Array<Situation>;
-    toEstimatedCall?: EstimatedCall;
-    toPlace: Place;
-    transportSubmode: TransportSubmode;
+    aimedEndTime: string
+    aimedStartTime: string
+    authority?: Authority
+    distance: number
+    directDuration: number
+    duration: number
+    expectedEndTime: string
+    expectedStartTime: string
+    fromEstimatedCall?: EstimatedCall
+    fromPlace: Place
+    interchangeFrom?: Interchange
+    interchangeTo?: Interchange
+    intermediateEstimatedCalls: Array<IntermediateEstimatedCall>
+    line?: Line
+    mode: LegMode
+    notices?: Array<Notice>
+    operator?: Operator
+    pointsOnLink: PointsOnLink
+    realtime: boolean
+    ride: boolean
+    rentedBike?: boolean
+    serviceJourney: ServiceJourney
+    situations: Array<Situation>
+    toEstimatedCall?: EstimatedCall
+    toPlace: Place
+    transportSubmode: TransportSubmode
 }
 
 export interface TransportSubmodeParam {
-    transportMode: TransportMode;
-    transportSubmodes: Array<TransportSubmode>;
+    transportMode: TransportMode
+    transportSubmodes: Array<TransportSubmode>
 }
 
 export interface InputBanned {
-    lines?: Array<string>;
-    authorities?: Array<string>;
-    organisations?: Array<string>;
-    quays?: Array<string>;
-    quaysHard?: Array<string>;
-    serviceJourneys?: Array<string>;
+    lines?: Array<string>
+    authorities?: Array<string>
+    organisations?: Array<string>
+    quays?: Array<string>
+    quaysHard?: Array<string>
+    serviceJourneys?: Array<string>
 }
 
 export interface InputWhiteListed {
-    lines?: Array<string>;
-    authorities?: Array<string>;
-    organisations?: Array<string>;
+    lines?: Array<string>
+    authorities?: Array<string>
+    organisations?: Array<string>
 }
 
 export interface GetTripPatternsParams {
-    from: Location;
-    to: Location;
-    allowBikeRental?: boolean;
-    arriveBy?: boolean;
-    limit?: number;
-    maxPreTransitWalkDistance?: number;
-    modes?: Array<QueryMode>;
-    searchDate?: Date;
-    transportSubmodes?: Array<TransportSubmodeParam>;
-    useFlex?: boolean;
-    walkSpeed?: number;
-    minimumTransferTime?: number;
-    wheelchairAccessible?: boolean;
-    banned?: InputBanned;
-    whiteListed?: InputWhiteListed;
+    from: Location
+    to: Location
+    allowBikeRental?: boolean
+    arriveBy?: boolean
+    limit?: number
+    maxPreTransitWalkDistance?: number
+    modes?: Array<QueryMode>
+    searchDate?: Date
+    transportSubmodes?: Array<TransportSubmodeParam>
+    useFlex?: boolean
+    walkSpeed?: number
+    minimumTransferTime?: number
+    wheelchairAccessible?: boolean
+    banned?: InputBanned
+    whiteListed?: InputWhiteListed
 }
 
 export interface TripPattern {
-    distance: number;
-    directDuration: number;
-    duration: number;
-    endTime: string;
-    id?: string;
-    legs: Array<Leg>;
-    startTime: string;
-    walkDistance: number;
+    distance: number
+    directDuration: number
+    duration: number
+    endTime: string
+    id?: string
+    legs: Array<Leg>
+    startTime: string
+    walkDistance: number
 }
 
 export interface GetDeparturesParams {
-    includeCancelledTrips?: boolean;
-    includeNonBoarding?: boolean;
-    limit?: number;
-    limitPerLine?: number;
-    start?: Date;
-    timeRange?: number;
-    whiteListedAuthorities?: Array<string>;
-    whiteListedLines?: Array<string>;
-    whiteListedModes?: Array<QueryMode>;
+    includeCancelledTrips?: boolean
+    includeNonBoarding?: boolean
+    limit?: number
+    limitPerLine?: number
+    start?: Date
+    timeRange?: number
+    whiteListedAuthorities?: Array<string>
+    whiteListedLines?: Array<string>
+    whiteListedModes?: Array<QueryMode>
 }
 
 export interface GetDeparturesBetweenStopPlacesParams {
-    limit?: number;
-    start?: Date;
+    limit?: number
+    start?: Date
 }
 
 /**
@@ -474,14 +476,14 @@ export type TypeName =
     | 'BikeRentalStation'
     | 'CarPark'
     | 'Quay'
-    | 'StopPlace';
+    | 'StopPlace'
 
 export interface NearestPlace {
-    id: string;
-    type: TypeName;
-    distance: number;
-    latitude: number;
-    longitude: number;
+    id: string
+    type: TypeName
+    distance: number
+    latitude: number
+    longitude: number
 }
 
 /**
@@ -489,48 +491,48 @@ export interface NearestPlace {
  */
 
 export interface DeparturesById {
-    id: string;
-    departures: Array<Departure>;
+    id: string
+    departures: Array<Departure>
 }
 
 export interface StopPlaceDetails {
-    id: string;
-    name: string;
-    description?: string;
-    latitude: number;
-    longitude: number;
-    wheelchairBoarding: 'noInformation' | 'possible' | 'notPossible';
+    id: string
+    name: string
+    description?: string
+    latitude: number
+    longitude: number
+    wheelchairBoarding: 'noInformation' | 'possible' | 'notPossible'
     weighting:
         | 'preferredInterchange'
         | 'recommendedInterchange'
         | 'interchangeAllowed'
-        | 'noInterchange';
-    transportMode: TransportMode;
-    transportSubmode?: TransportSubmode;
-    quays?: Array<Quay & { situations?: Situation[] }>;
+        | 'noInterchange'
+    transportMode: TransportMode
+    transportSubmode?: TransportSubmode
+    quays?: Array<Quay & { situations?: Situation[] }>
 }
 
-export type LimitationStatusType = 'FALSE' | 'TRUE' | 'PARTIAL' | 'UNKNOWN';
+export type LimitationStatusType = 'FALSE' | 'TRUE' | 'PARTIAL' | 'UNKNOWN'
 
 export interface WaitingRoomEquipment {
-    id: string;
+    id: string
 }
 
 export interface ShelterEquipment {
-    id: string;
+    id: string
 }
 
 export interface SanitaryEquipment {
-    id: string;
-    numberOfToilets: number;
-    gender: 'both' | 'femaleOnly' | 'maleOnly' | 'sameSexOnly';
+    id: string
+    numberOfToilets: number
+    gender: 'both' | 'femaleOnly' | 'maleOnly' | 'sameSexOnly'
 }
 
 export interface TicketingEquipment {
-    id: string;
-    ticketOffice: boolean;
-    ticketMachines: boolean;
-    numberOfMachines: number;
+    id: string
+    ticketOffice: boolean
+    ticketMachines: boolean
+    numberOfMachines: number
 }
 
 export type ParkingVehicle =
@@ -568,315 +570,317 @@ export type ParkingVehicle =
     | 'undefined'
     | 'other'
     | 'allPassengerVehicles'
-    | 'all';
+    | 'all'
 
 export interface StopPlaceFacilitiesStopPlace {
-    id: string;
-    name: MultilingualString;
+    id: string
+    name: MultilingualString
     accessibilityAssessment: {
         limitations: {
-            wheelchairAccess: LimitationStatusType;
-            stepFreeAccess: LimitationStatusType;
-        };
-    };
+            wheelchairAccess: LimitationStatusType
+            stepFreeAccess: LimitationStatusType
+        }
+    }
     placeEquipments: {
-        waitingRoomEquipment?: Array<WaitingRoomEquipment>;
-        shelterEquipment?: Array<ShelterEquipment>;
-        sanitaryEquipment?: Array<SanitaryEquipment>;
-        ticketingEquipment?: Array<TicketingEquipment>;
-    };
+        waitingRoomEquipment?: Array<WaitingRoomEquipment>
+        shelterEquipment?: Array<ShelterEquipment>
+        sanitaryEquipment?: Array<SanitaryEquipment>
+        ticketingEquipment?: Array<TicketingEquipment>
+    }
 }
 
 export interface StopPlaceFacilitiesParking {
-    name: MultilingualString;
-    parentSiteRef: string;
-    totalCapacity?: number;
-    principalCapacity?: number;
-    parkingVehicleTypes?: Array<ParkingVehicle>;
+    name: MultilingualString
+    parentSiteRef: string
+    totalCapacity?: number
+    principalCapacity?: number
+    parkingVehicleTypes?: Array<ParkingVehicle>
 }
 
 export interface StopPlaceFacilities {
-    stopPlace: Array<StopPlaceFacilitiesStopPlace>;
-    parking: Array<StopPlaceFacilitiesParking>;
+    stopPlace: Array<StopPlaceFacilitiesStopPlace>
+    parking: Array<StopPlaceFacilitiesParking>
 }
 
 export interface StopPlaceParams {
-    filterByInUse?: boolean;
+    filterByInUse?: boolean
 }
 
 export interface EnturService {
     journeyPlannerQuery: <journeyPlannerResponse>(
         queryObj: string,
         variables?: Record<string, any>,
-        config?: ServiceConfig
-    ) => Promise<journeyPlannerResponse>;
+        config?: ServiceConfig,
+    ) => Promise<journeyPlannerResponse>
 
     nsrQuery: <nsrResponse>(
         queryObj: string,
         variables?: Record<string, any>,
-        config?: ServiceConfig
-    ) => Promise<nsrResponse>;
+        config?: ServiceConfig,
+    ) => Promise<nsrResponse>
 
     getFeatures: (
         query: string,
         coords?: Coordinates,
-        params?: GetFeaturesParams
-    ) => Promise<Feature[]>;
+        params?: GetFeaturesParams,
+    ) => Promise<Feature[]>
 
     getFeaturesReverse: (
         coords: Coordinates,
-        params?: GetFeaturesReverseParam
-    ) => Promise<Feature[]>;
+        params?: GetFeaturesReverseParam,
+    ) => Promise<Feature[]>
 
     getTripPatterns: (
         params: GetTripPatternsParams,
-        overrideConfig?: OverrideConfig
-    ) => Promise<TripPattern[]>;
+        overrideConfig?: OverrideConfig,
+    ) => Promise<TripPattern[]>
 
     findTrips: (
         from: string,
         to: string,
-        date?: Date | string | number
-    ) => Promise<TripPattern[]>;
+        date?: Date | string | number,
+    ) => Promise<TripPattern[]>
 
     getDeparturesFromStopPlaces: (
         stopPlaceIds: Array<string>,
-        params?: GetDeparturesParams
-    ) => Promise<Array<DeparturesById | undefined>>;
+        params?: GetDeparturesParams,
+    ) => Promise<Array<DeparturesById | undefined>>
 
     getDeparturesFromStopPlace: (
         stopPlaceId: string,
-        params?: GetDeparturesParams
-    ) => Promise<Departure[]>;
+        params?: GetDeparturesParams,
+    ) => Promise<Departure[]>
 
     getDeparturesFromQuays: (
         quayIds: Array<string>,
-        params?: GetDeparturesParams
-    ) => Promise<Array<DeparturesById | undefined>>;
+        params?: GetDeparturesParams,
+    ) => Promise<Array<DeparturesById | undefined>>
 
     getDeparturesBetweenStopPlaces: (
         fromStopPlaceId: string,
         toStopPlaceId: string,
-        params?: GetDeparturesBetweenStopPlacesParams
-    ) => Promise<Departure[]>;
+        params?: GetDeparturesBetweenStopPlacesParams,
+    ) => Promise<Departure[]>
 
     getDeparturesForServiceJourney: (
         id: string,
-        date?: string
-    ) => Promise<Departure[]>;
+        date?: string,
+    ) => Promise<Departure[]>
 
     getNearestPlaces: (
         coordinates: Coordinates,
         params?: {
-            maximumDistance?: number;
-            maximumResults?: number;
-            filterByPlaceTypes?: Array<TypeName>;
-            filterByModes?: Array<TransportMode>;
-            filterByInUse?: boolean;
-            multiModalMode?: 'parent' | 'child' | 'all';
-        }
-    ) => Promise<Array<NearestPlace>>;
+            maximumDistance?: number
+            maximumResults?: number
+            filterByPlaceTypes?: Array<TypeName>
+            filterByModes?: Array<TransportMode>
+            filterByInUse?: boolean
+            multiModalMode?: 'parent' | 'child' | 'all'
+        },
+    ) => Promise<Array<NearestPlace>>
 
     getStopPlace: (
         id: string,
-        params?: StopPlaceParams
-    ) => Promise<StopPlaceDetails>;
+        params?: StopPlaceParams,
+    ) => Promise<StopPlaceDetails>
 
     getStopPlaces: (
         stopPlaceId: Array<string>,
-        params?: StopPlaceParams
-    ) => Promise<Array<StopPlaceDetails | undefined>>;
+        params?: StopPlaceParams,
+    ) => Promise<Array<StopPlaceDetails | undefined>>
 
     getParentStopPlace: (
         id: string,
-        params?: StopPlaceParams
-    ) => Promise<StopPlaceDetails | null>;
+        params?: StopPlaceParams,
+    ) => Promise<StopPlaceDetails | null>
 
     getStopPlacesByPosition: (
         coordinates: Coordinates,
-        distance?: number
-    ) => Promise<StopPlace[]>;
+        distance?: number,
+    ) => Promise<StopPlace[]>
 
-    getStopPlaceFacilities: (stopPlaceId: string) => Promise<StopPlaceFacilities>;
+    getStopPlaceFacilities: (
+        stopPlaceId: string,
+    ) => Promise<StopPlaceFacilities>
 
     getQuaysForStopPlace: (
         stopPlaceId: string,
-        params?: StopPlaceParams
-    ) => Promise<Quay[]>;
+        params?: StopPlaceParams,
+    ) => Promise<Quay[]>
 
-    getBikeRentalStation: (stationId: string) => Promise<BikeRentalStation>;
+    getBikeRentalStation: (stationId: string) => Promise<BikeRentalStation>
 
     getBikeRentalStations: (
-        stationIds: Array<string>
-    ) => Promise<Array<BikeRentalStation | undefined>>;
+        stationIds: Array<string>,
+    ) => Promise<Array<BikeRentalStation | undefined>>
 
     getBikeRentalStationsByPosition: (
         coordinates: Coordinates,
-        distance?: number
-    ) => Promise<BikeRentalStation[]>;
+        distance?: number,
+    ) => Promise<BikeRentalStation[]>
 }
 
-export default function createEnturService(config: Config): EnturService;
+export default function createEnturService(config: Config): EnturService
 
 /**
  * Constants
  */
 
 // Any for of public transportation
-export var AIR: 'air';
-export var BICYCLE: 'bicycle';
-export var BUS: 'bus';
-export var CABLEWAY: 'cableway';
-export var CAR: 'car';
-export var COACH: 'coach';
-export var WATER: 'water';
-export var FUNICULAR: 'funicular';
-export var LIFT: 'lift';
-export var RAIL: 'rail';
-export var METRO: 'metro';
-export var TRAM: 'tram';
-export var TRANSIT: 'transit';
-export var FOOT: 'foot';
+export var AIR: 'air'
+export var BICYCLE: 'bicycle'
+export var BUS: 'bus'
+export var CABLEWAY: 'cableway'
+export var CAR: 'car'
+export var COACH: 'coach'
+export var WATER: 'water'
+export var FUNICULAR: 'funicular'
+export var LIFT: 'lift'
+export var RAIL: 'rail'
+export var METRO: 'metro'
+export var TRAM: 'tram'
+export var TRANSIT: 'transit'
+export var FOOT: 'foot'
 
 // Combine with foot and transit for park and ride.
-export var CAR_PARK: 'car_park';
+export var CAR_PARK: 'car_park'
 
 // Combine with foot and transit for ride and kiss
-export var CAR_PICKUP: 'car_pickup';
+export var CAR_PICKUP: 'car_pickup'
 
-export var AIRPORT_LINK_RAIL: 'airportLinkRail';
-export var HIGH_SPEED_PASSENGER_SERVICE: 'highSpeedPassengerService';
-export var HIGH_SPEED_VEHICLE_SERVICE: 'highSpeedVehicleService';
-export var INTERNATIONAL_CAR_FERRY: 'internationalCarFerry';
-export var LOCAL_CAR_FERRY: 'localCarFerry';
-export var LOCAL_PASSENGER_FERRY: 'localPassengerFerry';
-export var NATIONAL_CAR_FERRY: 'nationalCarFerry';
-export var RAIL_REPLACEMENT_BUS: 'railReplacementBus';
-export var REGIONAL_CAR_FERRY: 'regionalCarFerry';
-export var TOURIST_RAILWAY: 'touristRailway';
-export var AIRPORT_LINK_BUS: 'airportLinkBus';
+export var AIRPORT_LINK_RAIL: 'airportLinkRail'
+export var HIGH_SPEED_PASSENGER_SERVICE: 'highSpeedPassengerService'
+export var HIGH_SPEED_VEHICLE_SERVICE: 'highSpeedVehicleService'
+export var INTERNATIONAL_CAR_FERRY: 'internationalCarFerry'
+export var LOCAL_CAR_FERRY: 'localCarFerry'
+export var LOCAL_PASSENGER_FERRY: 'localPassengerFerry'
+export var NATIONAL_CAR_FERRY: 'nationalCarFerry'
+export var RAIL_REPLACEMENT_BUS: 'railReplacementBus'
+export var REGIONAL_CAR_FERRY: 'regionalCarFerry'
+export var TOURIST_RAILWAY: 'touristRailway'
+export var AIRPORT_LINK_BUS: 'airportLinkBus'
 
 export var TransportMode: {
-    BUS: 'bus';
-    TRAM: 'tram';
-    RAIL: 'rail';
-    METRO: 'metro';
-    WATER: 'water';
-    AIR: 'air';
-    COACH: 'coach';
-    CAR: 'car';
-};
+    BUS: 'bus'
+    TRAM: 'tram'
+    RAIL: 'rail'
+    METRO: 'metro'
+    WATER: 'water'
+    AIR: 'air'
+    COACH: 'coach'
+    CAR: 'car'
+}
 
 export var LegMode: {
-    BUS: 'bus';
-    TRAM: 'tram';
-    RAIL: 'rail';
-    METRO: 'metro';
-    WATER: 'water';
-    AIR: 'air';
-    COACH: 'coach';
-    CAR: 'car';
-    FOOT: 'foot';
-    BICYCLE: 'bicycle';
-};
+    BUS: 'bus'
+    TRAM: 'tram'
+    RAIL: 'rail'
+    METRO: 'metro'
+    WATER: 'water'
+    AIR: 'air'
+    COACH: 'coach'
+    CAR: 'car'
+    FOOT: 'foot'
+    BICYCLE: 'bicycle'
+}
 
 export var TransportSubmode: {
-    AIRPORT_LINK_RAIL: 'airportLinkRail';
-    HIGH_SPEED_PASSENGER_SERVICE: 'highSpeedPassengerService';
-    HIGH_SPEED_VEHICLE_SERVICE: 'highSpeedVehicleService';
-    INTERNATIONAL_CAR_FERRY: 'internationalCarFerry';
-    LOCAL_CAR_FERRY: 'localCarFerry';
-    LOCAL_PASSENGER_FERRY: 'localPassengerFerry';
-    NATIONAL_CAR_FERRY: 'nationalCarFerry';
-    RAIL_REPLACEMENT_BUS: 'railReplacementBus';
-    REGIONAL_CAR_FERRY: 'regionalCarFerry';
-    TOURIST_RAILWAY: 'touristRailway';
-    AIRPORT_LINK_BUS: 'airportLinkBus';
-    CITY_TRAM: 'cityTram';
-};
+    AIRPORT_LINK_RAIL: 'airportLinkRail'
+    HIGH_SPEED_PASSENGER_SERVICE: 'highSpeedPassengerService'
+    HIGH_SPEED_VEHICLE_SERVICE: 'highSpeedVehicleService'
+    INTERNATIONAL_CAR_FERRY: 'internationalCarFerry'
+    LOCAL_CAR_FERRY: 'localCarFerry'
+    LOCAL_PASSENGER_FERRY: 'localPassengerFerry'
+    NATIONAL_CAR_FERRY: 'nationalCarFerry'
+    RAIL_REPLACEMENT_BUS: 'railReplacementBus'
+    REGIONAL_CAR_FERRY: 'regionalCarFerry'
+    TOURIST_RAILWAY: 'touristRailway'
+    AIRPORT_LINK_BUS: 'airportLinkBus'
+    CITY_TRAM: 'cityTram'
+}
 
-export var ONSTREET_BUS: 'onstreetBus';
-export var ONSTREET_TRAM: 'onstreetTram';
-export var AIRPORT: 'airport';
-export var RAIL_STATION: 'railStation';
-export var METRO_STATION: 'metroStation';
-export var BUS_STATION: 'busStation';
-export var COACH_STATION: 'coachStation';
-export var TRAM_STATION: 'tramStation';
-export var HARBOUR_PORT: 'harbourPort';
-export var FERRY_PORT: 'ferryPort';
-export var FERRY_STOP: 'ferryStop';
-export var LIFT_STATION: 'liftStation';
-export var VEHICLE_RAIL_INTERCHANGE: 'vehicleRailInterchange';
-export var GROUP_OF_STOP_PLACES: 'GroupOfStopPlaces';
-export var POI: 'poi';
-export var VEGADRESSE: 'Vegadresse';
-export var STREET: 'street';
-export var TETTSTEDDEL: 'tettsteddel';
-export var BYDEL: 'bydel';
-export var OTHER: 'other';
+export var ONSTREET_BUS: 'onstreetBus'
+export var ONSTREET_TRAM: 'onstreetTram'
+export var AIRPORT: 'airport'
+export var RAIL_STATION: 'railStation'
+export var METRO_STATION: 'metroStation'
+export var BUS_STATION: 'busStation'
+export var COACH_STATION: 'coachStation'
+export var TRAM_STATION: 'tramStation'
+export var HARBOUR_PORT: 'harbourPort'
+export var FERRY_PORT: 'ferryPort'
+export var FERRY_STOP: 'ferryStop'
+export var LIFT_STATION: 'liftStation'
+export var VEHICLE_RAIL_INTERCHANGE: 'vehicleRailInterchange'
+export var GROUP_OF_STOP_PLACES: 'GroupOfStopPlaces'
+export var POI: 'poi'
+export var VEGADRESSE: 'Vegadresse'
+export var STREET: 'street'
+export var TETTSTEDDEL: 'tettsteddel'
+export var BYDEL: 'bydel'
+export var OTHER: 'other'
 
 export var FeatureCategory: {
-    ONSTREET_BUS: 'onstreetBus';
-    ONSTREET_TRAM: 'onstreetTram';
-    AIRPORT: 'airport';
-    RAIL_STATION: 'railStation';
-    METRO_STATION: 'metroStation';
-    BUS_STATION: 'busStation';
-    COACH_STATION: 'coachStation';
-    TRAM_STATION: 'tramStation';
-    HARBOUR_PORT: 'harbourPort';
-    FERRY_PORT: 'ferryPort';
-    FERRY_STOP: 'ferryStop';
-    LIFT_STATION: 'liftStation';
-    VEHICLE_RAIL_INTERCHANGE: 'vehicleRailInterchange';
-    GROUP_OF_STOP_PLACES: 'GroupOfStopPlaces';
-    POI: 'poi';
-    VEGADRESSE: 'Vegadresse';
-    STREET: 'street';
-    TETTSTEDDEL: 'tettsteddel';
-    BYDEL: 'bydel';
-    OTHER: 'other';
-};
+    ONSTREET_BUS: 'onstreetBus'
+    ONSTREET_TRAM: 'onstreetTram'
+    AIRPORT: 'airport'
+    RAIL_STATION: 'railStation'
+    METRO_STATION: 'metroStation'
+    BUS_STATION: 'busStation'
+    COACH_STATION: 'coachStation'
+    TRAM_STATION: 'tramStation'
+    HARBOUR_PORT: 'harbourPort'
+    FERRY_PORT: 'ferryPort'
+    FERRY_STOP: 'ferryStop'
+    LIFT_STATION: 'liftStation'
+    VEHICLE_RAIL_INTERCHANGE: 'vehicleRailInterchange'
+    GROUP_OF_STOP_PLACES: 'GroupOfStopPlaces'
+    POI: 'poi'
+    VEGADRESSE: 'Vegadresse'
+    STREET: 'street'
+    TETTSTEDDEL: 'tettsteddel'
+    BYDEL: 'bydel'
+    OTHER: 'other'
+}
 
 /**
  * Utils
  */
 
 export function getTripPatternsQuery(
-    params: GetTripPatternsParams
-): { query: string; variables?: Record<string, any> };
+    params: GetTripPatternsParams,
+): { query: string; variables?: Record<string, any> }
 
-export function convertFeatureToLocation(feature: Feature): Location;
-export function convertLocationToPosition(feature: Feature): Location;
+export function convertFeatureToLocation(feature: Feature): Location
+export function convertLocationToPosition(feature: Feature): Location
 export function convertPositionToBbox(
     coordinates: Coordinates,
-    distance: number
+    distance: number,
 ): {
-    minLng: number;
-    minLat: number;
-    maxLng: number;
-    maxLat: number;
-};
+    minLng: number
+    minLat: number
+    maxLng: number
+    maxLat: number
+}
 
 export function throttler<T, U>(
     func: (arg: T) => Promise<U>,
-    args: T[]
-): Promise<U[]>;
+    args: T[],
+): Promise<U[]>
 
-export function isAir(mode: string): boolean;
-export function isBicycle(mode: string): boolean;
-export function isBus(mode: string): boolean;
-export function isCableway(mode: string): boolean;
-export function isCar(mode: string): boolean;
-export function isCoach(mode: string): boolean;
-export function isWater(mode: string): boolean;
-export function isFunicular(mode: string): boolean;
-export function isLift(mode: string): boolean;
-export function isRail(mode: string): boolean;
-export function isMetro(mode: string): boolean;
-export function isTram(mode: string): boolean;
-export function isTransit(mode: string): boolean;
-export function isFoot(mode: string): boolean;
-export function isCarPark(mode: string): boolean;
-export function isCarPickup(mode: string): boolean;
+export function isAir(mode: string): boolean
+export function isBicycle(mode: string): boolean
+export function isBus(mode: string): boolean
+export function isCableway(mode: string): boolean
+export function isCar(mode: string): boolean
+export function isCoach(mode: string): boolean
+export function isWater(mode: string): boolean
+export function isFunicular(mode: string): boolean
+export function isLift(mode: string): boolean
+export function isRail(mode: string): boolean
+export function isMetro(mode: string): boolean
+export function isTram(mode: string): boolean
+export function isTransit(mode: string): boolean
+export function isFoot(mode: string): boolean
+export function isCarPark(mode: string): boolean
+export function isCarPickup(mode: string): boolean

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -90,6 +90,10 @@ type $entur$sdk$Config = {|
         nsr?: string,
     },
     headers?: {[string]: string},
+    fetch?: (
+        url: string,
+        init?: Object,
+    ) => Promise<any>
 |}
 
 type $entur$sdk$OverrideConfig = {|
@@ -100,6 +104,10 @@ type $entur$sdk$OverrideConfig = {|
         nsr?: string,
     },
     headers?: {[string]: string},
+    fetch?: (
+        url: string,
+        init?: Object,
+    ) => Promise<any>
 |}
 
 type $entur$sdk$Coordinates = {

--- a/src/api.ts
+++ b/src/api.ts
@@ -41,7 +41,9 @@ export function journeyPlannerQuery<T>(
 
     const params = getGraphqlParams(queryObj, variables)
 
-    return post(url, params, headers).then(errorHandler)
+    return post(url, params, headers, undefined, config.fetch).then(
+        errorHandler,
+    )
 }
 
 export function nsrQuery<T>(
@@ -52,7 +54,12 @@ export function nsrQuery<T>(
     const { host, headers } = getNSRHost(config)
     const url = `${host}/graphql`
 
-    return post(url, { query: minify(query), variables }, headers).then(
+    const params = {
+        query: minify(query),
+        variables,
+    }
+
+    return post(url, params, headers, undefined, config.fetch).then(
         errorHandler,
     )
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { Response } from 'node-fetch'
+
 export interface HostConfig {
     host: string
     headers?: { [key: string]: string }
@@ -11,6 +13,10 @@ export interface ServiceConfig {
         nsr: string
     }
     headers: { [key: string]: string }
+    fetch?: (
+        url: RequestInfo,
+        init?: RequestInit | undefined,
+    ) => Promise<Response>
 }
 
 export interface ArgumentConfig {
@@ -21,6 +27,10 @@ export interface ArgumentConfig {
         nsr?: string
     }
     headers?: { [key: string]: string }
+    fetch?: (
+        url: RequestInfo,
+        init?: RequestInit | undefined,
+    ) => Promise<Response>
 }
 
 export interface OverrideConfig {
@@ -31,6 +41,10 @@ export interface OverrideConfig {
         nsr?: string
     }
     headers?: { [key: string]: string }
+    fetch?: (
+        url: RequestInfo,
+        init?: RequestInit | undefined,
+    ) => Promise<Response>
 }
 
 const HOST_CONFIG = {
@@ -47,7 +61,7 @@ export function getServiceConfig(config: ArgumentConfig): ServiceConfig {
         )
     }
 
-    const { clientName, hosts = {}, headers = {} } = config
+    const { clientName, hosts = {}, headers = {}, fetch } = config
 
     return {
         clientName,
@@ -56,6 +70,7 @@ export function getServiceConfig(config: ArgumentConfig): ServiceConfig {
             ...HOST_CONFIG,
             ...hosts,
         },
+        fetch,
     }
 }
 
@@ -112,6 +127,7 @@ export function mergeConfig(
     return {
         ...config,
         clientName: override.clientName || config.clientName,
+        fetch: override.fetch || config.fetch,
         hosts: {
             ...config.hosts,
             ...override.hosts,

--- a/src/http.ts
+++ b/src/http.ts
@@ -21,8 +21,14 @@ export function get<T extends object>(
     params?: object,
     headers?: object,
     config?: object,
+    customFetch?: (
+        url: RequestInfo,
+        init?: RequestInit | undefined,
+    ) => Promise<Response>,
 ): Promise<T> {
-    return fetch(`${url}?${qs.stringify(params)}`, {
+    const fetcher = customFetch || fetch
+
+    return fetcher(`${url}?${qs.stringify(params)}`, {
         method: 'get',
         ...config,
         headers: { ...DEFAULT_HEADERS, ...headers },
@@ -39,8 +45,14 @@ export function post<T>(
     params?: object,
     headers?: object,
     config?: object,
+    customFetch?: (
+        url: RequestInfo,
+        init?: RequestInit | undefined,
+    ) => Promise<Response>,
 ): Promise<T> {
-    return fetch(url, {
+    const fetcher = customFetch || fetch
+
+    return fetcher(url, {
         method: 'post',
         ...config,
         headers: { ...DEFAULT_HEADERS, ...headers },


### PR DESCRIPTION
If you need to configure the fetch implementation that is used. You could use this for:
* Specifying default headers
* Specifying custom agents #140 
* Do some common logging on all SDK requests

```
const service = createEnturService({
  clientName: 'awesomecompany-awesomeapp',
  fetch: (url, init) => {
    const startTime = new Date()
    console.log(`Request at: ${startTime.toString()}`)
    return fetch(url, {
      agent: new HttpsAgent({ keepAlive: true }),
      ...init,
      headers: {
        'My-Default-Header': 'cheese',
        ...init.headers
      }
    }).then(res => {
      console.log(`Response after ${new Date() - startTime} ms`)
      return res
    })
  }
})
```