### PR TITLE
Upgrade Prettier to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
 
     working_directory: ~/sdk
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,9 @@
 module.exports = {
     root: true,
     parser: '@typescript-eslint/parser',
+    env: {
+        node: true,
+    },
     plugins: [
         '@typescript-eslint',
         'prettier',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9405,6 +9405,14 @@
         "unist-util-find": "^1.0.1",
         "unist-util-is": "^3.0.0",
         "unist-util-visit": "^1.4.1"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "1.19.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+          "dev": true
+        }
       }
     },
     "dom-converter": {
@@ -12540,7 +12548,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -22497,9 +22506,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.1.tgz",
+      "integrity": "sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "firebase-tools": "^7.15.1",
     "flow-bin": "^0.89.0",
     "gatsby-theme-docz": "^2.2.0",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
     "ts-node": "^8.7.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "libdef.flow.js"
   ],
   "scripts": {
-    "lint": "eslint src/ --ext=js,ts",
+    "lint": "eslint src/ types/ scripts/ --ext=js,ts",
     "test": "npm run lint && npm run check-libdefs && ts-node scripts/validate-queries.js && tsc --noEmit -p .",
     "check-libdefs": "flow && tsc index.d.ts --noEmit",
     "prebuild": "npm test && rm -rf lib",

--- a/scripts/fetch-schemas.ts
+++ b/scripts/fetch-schemas.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import fetch from 'node-fetch'
 
-import { getIntrospectionQuery } from 'graphql';
+import { getIntrospectionQuery } from 'graphql'
 
 const { writeFile } = fs.promises
 
@@ -14,14 +14,22 @@ function runIntrospectionQuery(url: string): Promise<object> {
         },
         body: JSON.stringify({
             query: getIntrospectionQuery(),
-            operationName: 'IntrospectionQuery'
-        })
-    })
-    .then(res => res.json())
+            operationName: 'IntrospectionQuery',
+        }),
+    }).then((res) => res.json())
 }
 
-runIntrospectionQuery('https://api.entur.io/journey-planner/v2/graphql')
-    .then(schema => writeFile('schemas/journeyplanner2.json', JSON.stringify(schema, undefined, 2)))
+runIntrospectionQuery(
+    'https://api.entur.io/journey-planner/v2/graphql',
+).then((schema) =>
+    writeFile(
+        'schemas/journeyplanner2.json',
+        JSON.stringify(schema, undefined, 2),
+    ),
+)
 
-runIntrospectionQuery('https://api.entur.io/stop-places/v1/graphql')
-    .then(schema => writeFile('schemas/nsr.json', JSON.stringify(schema, undefined, 2)))
+runIntrospectionQuery(
+    'https://api.entur.io/stop-places/v1/graphql',
+).then((schema) =>
+    writeFile('schemas/nsr.json', JSON.stringify(schema, undefined, 2)),
+)

--- a/scripts/validate-queries.js
+++ b/scripts/validate-queries.js
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies, no-console */
+/* eslint-disable no-console */
 
 /*
 This is a script that validates queries against the GraphQL schemas for JourneyPlanner and NSR.
@@ -24,9 +24,7 @@ import {
     getDeparturesForServiceJourneyQuery,
 } from '../src/departure/query'
 
-import {
-    getNearestPlacesQuery,
-} from '../src/nearest/query'
+import { getNearestPlacesQuery } from '../src/nearest/query'
 
 import {
     getStopPlaceQuery,
@@ -37,9 +35,7 @@ import {
     getQuaysForStopPlaceQuery,
 } from '../src/stopPlace/query'
 
-import {
-    getTripPatternQuery,
-} from '../src/trip/query'
+import { getTripPatternQuery } from '../src/trip/query'
 
 const journeyplanner2Schema = buildClientSchema(journeyplanner2SchemaJSON.data)
 const nsrSchema = buildClientSchema(nsrSchemaJSON.data)
@@ -61,9 +57,7 @@ const jp2Queries = [
     { getTripPatternQuery },
 ]
 
-const nsrQueries = [
-    { getStopPlaceFacilitiesQuery },
-]
+const nsrQueries = [{ getStopPlaceFacilitiesQuery }]
 
 function validateQuery(queryName, query, schema) {
     try {

--- a/src/bikeRental/index.ts
+++ b/src/bikeRental/index.ts
@@ -26,7 +26,7 @@ export function createGetBikeRentalStation(argConfig: ArgumentConfig) {
             getBikeRentalStationQuery,
             variables,
             config,
-        ).then(data => data?.bikeRentalStation)
+        ).then((data) => data?.bikeRentalStation)
     }
 }
 
@@ -53,8 +53,10 @@ export function createGetBikeRentalStations(argConfig: ArgumentConfig) {
         return journeyPlannerQuery<{
             bikeRentalStations?: BikeRentalStation[]
         }>(getBikeRentalStationsQuery, variables, config)
-            .then(data => data?.bikeRentalStations || [])
-            .then(stations => forceOrder(stations, stationIds, ({ id }) => id))
+            .then((data) => data?.bikeRentalStations || [])
+            .then((stations) =>
+                forceOrder(stations, stationIds, ({ id }) => id),
+            )
     }
 }
 
@@ -72,7 +74,7 @@ export function createGetBikeRentalStationsByPosition(
         return journeyPlannerQuery<{
             bikeRentalStationsByBbox?: BikeRentalStation[]
         }>(getBikeRentalStationsByPositionQuery, variables, config).then(
-            data => data?.bikeRentalStationsByBbox || [],
+            (data) => data?.bikeRentalStationsByBbox || [],
         )
     }
 }

--- a/src/departure/index.ts
+++ b/src/departure/index.ts
@@ -91,7 +91,7 @@ export function createGetDeparturesFromStopPlaces(argConfig: ArgumentConfig) {
         return journeyPlannerQuery<{
             stopPlaces?: Array<{ id: string; estimatedCalls: EstimatedCall[] }>
         }>(getDeparturesFromStopPlacesQuery, variables, config)
-            .then(data => {
+            .then((data) => {
                 if (!data?.stopPlaces) {
                     throw new Error(
                         `Missing data: getDeparturesFromStopPlaces received no data from the API.`,
@@ -169,7 +169,7 @@ export function createGetDeparturesFromQuays(argConfig: ArgumentConfig) {
         return journeyPlannerQuery<{
             quays?: Array<{ estimatedCalls: EstimatedCall[]; id: string }>
         }>(getDeparturesFromQuayQuery, variables, config)
-            .then(data => {
+            .then((data) => {
                 if (!data || !data?.quays) {
                     throw new Error(
                         `Missing data: getDeparturesFromQuays received no data from the API.`,
@@ -215,11 +215,11 @@ export function createGetDeparturesBetweenStopPlaces(
         return journeyPlannerQuery<{
             trip: { tripPatterns: Array<{ legs: Leg[] }> }
         }>(getDeparturesBetweenStopPlacesQuery, variables, config).then(
-            data => {
+            (data) => {
                 if (!data || !data?.trip?.tripPatterns) return []
 
                 return data.trip.tripPatterns
-                    .map(trip => {
+                    .map((trip) => {
                         const [leg] = trip.legs
                         if (!leg) return undefined
 
@@ -248,7 +248,7 @@ export function createGetDeparturesForServiceJourney(
         return journeyPlannerQuery<{
             serviceJourney?: { estimatedCalls: EstimatedCall[] }
         }>(getDeparturesForServiceJourneyQuery, variables, config).then(
-            data => {
+            (data) => {
                 return (data?.serviceJourney?.estimatedCalls || []).map(
                     destinationMapper,
                 )

--- a/src/departure/mapper.ts
+++ b/src/departure/mapper.ts
@@ -11,7 +11,7 @@ function getNoticesFromLeg(leg: Leg): Array<Notice> {
         ...(leg.serviceJourney?.journeyPattern?.line?.notices || []),
         ...(leg.fromEstimatedCall?.notices || []),
     ]
-    return uniqBy(notices, notice => notice.text)
+    return uniqBy(notices, (notice) => notice.text)
 }
 
 function getNotices(departure: EstimatedCall): Array<Notice> {
@@ -21,7 +21,7 @@ function getNotices(departure: EstimatedCall): Array<Notice> {
         ...(departure.serviceJourney?.journeyPattern?.notices || []),
         ...(departure.serviceJourney?.journeyPattern?.line?.notices || []),
     ]
-    return uniqBy(notices, notice => notice.text)
+    return uniqBy(notices, (notice) => notice.text)
 }
 
 export function destinationMapper(departure: EstimatedCall): EstimatedCall {

--- a/src/geocoder/index.ts
+++ b/src/geocoder/index.ts
@@ -62,7 +62,7 @@ export function createGetFeatures(argConfig: ArgumentConfig) {
             headers,
             undefined,
             config.fetch,
-        ).then(data => data.features || [])
+        ).then((data) => data.features || [])
     }
 }
 
@@ -99,6 +99,6 @@ export function createGetFeaturesReverse(argConfig: ArgumentConfig) {
             headers,
             undefined,
             config.fetch,
-        ).then(data => data.features || [])
+        ).then((data) => data.features || [])
     }
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -34,8 +34,8 @@ export function get<T extends object>(
         headers: { ...DEFAULT_HEADERS, ...headers },
     })
         .then(responseHandler)
-        .then(res => res.json())
-        .then(data =>
+        .then((res) => res.json())
+        .then((data) =>
             cleanDeep(data, { emptyArrays: false, emptyStrings: false }),
         )
 }
@@ -59,8 +59,8 @@ export function post<T>(
         body: JSON.stringify(params),
     })
         .then(responseHandler)
-        .then(res => res.json())
-        .then(data =>
+        .then((res) => res.json())
+        .then((data) =>
             cleanDeep(data, { emptyArrays: false, emptyStrings: false }),
         )
 }

--- a/src/nearest/index.ts
+++ b/src/nearest/index.ts
@@ -107,7 +107,7 @@ export function createGetNearestPlaces(argConfig: ArgumentConfig) {
             getNearestPlacesQuery,
             variables,
             config,
-        ).then(data =>
+        ).then((data) =>
             (data?.nearest?.edges || []).map(({ node }) => {
                 const { distance, place } = node
 

--- a/src/stopPlace/index.ts
+++ b/src/stopPlace/index.ts
@@ -37,7 +37,7 @@ export function createGetStopPlace(argConfig: ArgumentConfig) {
             getStopPlaceQuery,
             variables,
             config,
-        ).then(data => data?.stopPlace)
+        ).then((data) => data?.stopPlace)
     }
 }
 
@@ -70,7 +70,7 @@ export function createGetStopPlaces(argConfig: ArgumentConfig) {
             variables,
             config,
         )
-            .then(data => data?.stopPlaces || [])
+            .then((data) => data?.stopPlaces || [])
             .then((stopPlaceDetails: StopPlaceDetails[]) => {
                 return forceOrder(
                     stopPlaceDetails,
@@ -98,7 +98,7 @@ export function createGetParentStopPlace(argConfig: ArgumentConfig) {
         return journeyPlannerQuery<{
             stopPlace?: { parent?: StopPlaceDetails }
         }>(getParentStopPlaceQuery, variables, config).then(
-            data => data?.stopPlace?.parent,
+            (data) => data?.stopPlace?.parent,
         )
     }
 }
@@ -122,7 +122,7 @@ export function createGetStopPlacesByPosition(argConfig: ArgumentConfig) {
             getStopPlacesByBboxQuery,
             variables,
             config,
-        ).then(data => data?.stopPlacesByBbox || [])
+        ).then((data) => data?.stopPlacesByBbox || [])
     }
 }
 
@@ -155,6 +155,6 @@ export function createGetQuaysForStopPlace(argConfig: ArgumentConfig) {
             getQuaysForStopPlaceQuery,
             variables,
             config,
-        ).then(data => data?.stopPlace?.quays || [])
+        ).then((data) => data?.stopPlace?.quays || [])
     }
 }

--- a/src/trip/index.ts
+++ b/src/trip/index.ts
@@ -137,12 +137,12 @@ export function createGetTripPatterns(argConfig: ArgumentConfig) {
             getTripPatternQuery,
             getTripPatternsVariables(params),
             mergeConfig(config, overrideConfig),
-        ).then(data => {
+        ).then((data) => {
             if (!data?.trip?.tripPatterns) {
                 return []
             }
 
-            return data.trip.tripPatterns.map(trip => ({
+            return data.trip.tripPatterns.map((trip) => ({
                 ...trip,
                 legs: trip.legs.map(legMapper),
             }))

--- a/src/trip/mapper.ts
+++ b/src/trip/mapper.ts
@@ -27,7 +27,7 @@ export function getNotices(leg: Leg): Array<Notice> {
         ...(leg.toEstimatedCall?.notices || []),
         ...(leg.line?.notices || []),
     ]
-    return uniqBy(notices, notice => notice.text)
+    return uniqBy(notices, (notice) => notice.text)
 }
 
 function authorityMapper(authority?: Authority): Authority | undefined {

--- a/src/trip/query.ts
+++ b/src/trip/query.ts
@@ -26,7 +26,7 @@ const declaration = Object.entries(variables)
     .join(',')
 
 const invocation = Object.keys(variables)
-    .map(key => `${key}: $${key}`)
+    .map((key) => `${key}: $${key}`)
     .join(',')
 
 export const getTripPatternQuery = `

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -78,7 +78,7 @@ export function throttler<T, V>(
     }
 
     const promiseThrottle = new PromiseThrottle({ requestsPerSecond })
-    return Promise.all(args.map(a => promiseThrottle.add(() => func(a))))
+    return Promise.all(args.map((a) => promiseThrottle.add(() => func(a))))
 }
 
 export function isValidDate(d: any): boolean {
@@ -123,11 +123,11 @@ export function forceOrder<T, V>(
 
     const getKeyFunc = getKey || identity
 
-    sequence.forEach(sequenceIdentifier => {
-        const item = queue.find(t => getKeyFunc(t) === sequenceIdentifier)
+    sequence.forEach((sequenceIdentifier) => {
+        const item = queue.find((t) => getKeyFunc(t) === sequenceIdentifier)
         if (item) {
             result.push(item)
-            queue = queue.filter(q => q !== item)
+            queue = queue.filter((q) => q !== item)
         } else {
             result.push(undefined)
         }

--- a/types/BookingArrangement.ts
+++ b/types/BookingArrangement.ts
@@ -1,17 +1,17 @@
 export type BookingMethod = 'callOffice' | 'online'
 
 export interface BookingContact {
-  phone: string;
-  url: string;
+    phone: string
+    url: string
 }
 
 export interface BookingArrangement {
-  bookingAccess: boolean;
-  bookingContact: BookingContact;
-  latestBookingTime: string;
-  bookingMethods?: Array<BookingMethod>;
-  bookWhen?: string;
-  minimumBookingPeriod?: string;
-  bookingNote?: string;
-  buyWhen: string;
+    bookingAccess: boolean
+    bookingContact: BookingContact
+    latestBookingTime: string
+    bookingMethods?: Array<BookingMethod>
+    bookWhen?: string
+    minimumBookingPeriod?: string
+    bookingNote?: string
+    buyWhen: string
 }

--- a/types/Coordinates.ts
+++ b/types/Coordinates.ts
@@ -1,4 +1,4 @@
 export interface Coordinates {
-    latitude: number;
-    longitude: number;
+    latitude: number
+    longitude: number
 }

--- a/types/DestinationDisplay.ts
+++ b/types/DestinationDisplay.ts
@@ -1,3 +1,3 @@
 export interface DestinationDisplay {
-    frontText: string;
+    frontText: string
 }

--- a/types/Feature.ts
+++ b/types/Feature.ts
@@ -23,28 +23,28 @@ export type Category =
 
 export type Feature = {
     geometry: {
-        coordinates: [number, number]; // longitude, latitude
-        type: 'Point';
-    };
+        coordinates: [number, number] // longitude, latitude
+        type: 'Point'
+    }
     properties: {
-        id: string;
-        name: string;
-        label?: string;
-        borough: string;
-        accuracy: 'point';
-        layer: 'venue' | 'address';
-        borough_gid: string;
-        category: Array<Category>;
-        country_gid: string;
-        county: string;
-        county_gid: string;
-        gid: string;
-        housenumber?: string;
-        locality: string;
-        locality_gid: string;
-        postalcode: string;
-        source: string;
-        source_id: string;
-        street: string;
-    };
+        id: string
+        name: string
+        label?: string
+        borough: string
+        accuracy: 'point'
+        layer: 'venue' | 'address'
+        borough_gid: string
+        category: Array<Category>
+        country_gid: string
+        county: string
+        county_gid: string
+        gid: string
+        housenumber?: string
+        locality: string
+        locality_gid: string
+        postalcode: string
+        source: string
+        source_id: string
+        street: string
+    }
 }

--- a/types/Interchange.ts
+++ b/types/Interchange.ts
@@ -1,4 +1,4 @@
 export type Interchange = {
-    guaranteed: boolean;
-    staySeated: boolean;
+    guaranteed: boolean
+    staySeated: boolean
 }

--- a/types/Location.ts
+++ b/types/Location.ts
@@ -1,7 +1,7 @@
 import { Coordinates } from './Coordinates'
 
 export interface Location {
-    name?: string;
-    place?: string;
-    coordinates?: Coordinates;
+    name?: string
+    place?: string
+    coordinates?: Coordinates
 }

--- a/types/Mode.ts
+++ b/types/Mode.ts
@@ -31,11 +31,7 @@ export type QueryMode =
     | 'transit'
     | 'water'
 
-export type LegMode =
-    | TransportMode
-    | 'bicycle'
-    | 'car'
-    | 'foot'
+export type LegMode = TransportMode | 'bicycle' | 'car' | 'foot'
 
 export type TransportSubmode =
     | 'localBus'

--- a/types/MultilingualString.ts
+++ b/types/MultilingualString.ts
@@ -1,5 +1,5 @@
 export interface MultilingualString {
-    lang: 'eng' | 'nob' | 'nno';
-    language?: 'en' | 'nb' | 'nn' | 'no';
-    value: string;
+    lang: 'eng' | 'nob' | 'nno'
+    language?: 'en' | 'nb' | 'nn' | 'no'
+    value: string
 }

--- a/types/NearestPlace.ts
+++ b/types/NearestPlace.ts
@@ -6,9 +6,9 @@ export type TypeName =
     | 'StopPlace'
 
 export interface NearestPlace {
-    id: string;
-    type: TypeName;
-    distance: number;
-    latitude: number;
-    longitude: number;
+    id: string
+    type: TypeName
+    distance: number
+    latitude: number
+    longitude: number
 }

--- a/types/PointsOnLink.ts
+++ b/types/PointsOnLink.ts
@@ -1,4 +1,4 @@
 export interface PointsOnLink {
-    points: string;
-    length: number;
+    points: string
+    length: number
 }

--- a/types/StopPlace.ts
+++ b/types/StopPlace.ts
@@ -4,39 +4,43 @@ import { TransportMode, TransportSubmode } from './Mode'
 import { Quay } from '../src/fields/Quay'
 
 export interface StopPlaceDetails {
-    id: string;
-    name: string;
-    description?: string;
-    latitude: number;
-    longitude: number;
-    wheelchairBoarding: 'noInformation' | 'possible' | 'notPossible';
-    weighting: 'preferredInterchange' | 'recommendedInterchange' | 'interchangeAllowed' | 'noInterchange';
-    transportMode: TransportMode;
-    transportSubmode?: TransportSubmode;
-    quays?: Array<Quay>;
+    id: string
+    name: string
+    description?: string
+    latitude: number
+    longitude: number
+    wheelchairBoarding: 'noInformation' | 'possible' | 'notPossible'
+    weighting:
+        | 'preferredInterchange'
+        | 'recommendedInterchange'
+        | 'interchangeAllowed'
+        | 'noInterchange'
+    transportMode: TransportMode
+    transportSubmode?: TransportSubmode
+    quays?: Array<Quay>
 }
 
 type LimitationStatusType = 'FALSE' | 'TRUE' | 'PARTIAL' | 'UNKNOWN'
 
 type WaitingRoomEquipment = {
-    id: string;
+    id: string
 }
 
 type ShelterEquipment = {
-    id: string;
+    id: string
 }
 
 type SanitaryEquipment = {
-    id: string;
-    numberOfToilets: number;
-    gender: 'both' | 'femaleOnly' | 'maleOnly' | 'sameSexOnly';
+    id: string
+    numberOfToilets: number
+    gender: 'both' | 'femaleOnly' | 'maleOnly' | 'sameSexOnly'
 }
 
 type TicketingEquipment = {
-    id: string;
-    ticketOffice: boolean;
-    ticketMachines: boolean;
-    numberOfMachines: number;
+    id: string
+    ticketOffice: boolean
+    ticketMachines: boolean
+    numberOfMachines: number
 }
 
 type ParkingVehicle =
@@ -77,31 +81,31 @@ type ParkingVehicle =
     | 'all'
 
 interface StopPlaceFacilitiesStopPlace {
-    id: string;
-    name: MultilingualString;
+    id: string
+    name: MultilingualString
     accessibilityAssessment: {
         limitations: {
-            wheelchairAccess: LimitationStatusType;
-            stepFreeAccess: LimitationStatusType;
-        };
-    };
+            wheelchairAccess: LimitationStatusType
+            stepFreeAccess: LimitationStatusType
+        }
+    }
     placeEquipments: {
-        waitingRoomEquipment?: Array<WaitingRoomEquipment>;
-        shelterEquipment?: Array<ShelterEquipment>;
-        sanitaryEquipment?: Array<SanitaryEquipment>;
-        ticketingEquipment?: Array<TicketingEquipment>;
-    };
+        waitingRoomEquipment?: Array<WaitingRoomEquipment>
+        shelterEquipment?: Array<ShelterEquipment>
+        sanitaryEquipment?: Array<SanitaryEquipment>
+        ticketingEquipment?: Array<TicketingEquipment>
+    }
 }
 
 interface StopPlaceFacilitiesParking {
-    name: MultilingualString;
-    parentSiteRef: string;
-    totalCapacity?: number;
-    principalCapacity?: number;
-    parkingVehicleTypes?: Array<ParkingVehicle>;
+    name: MultilingualString
+    parentSiteRef: string
+    totalCapacity?: number
+    principalCapacity?: number
+    parkingVehicleTypes?: Array<ParkingVehicle>
 }
 
 export interface StopPlaceFacilities {
-    stopPlace: Array<StopPlaceFacilitiesStopPlace>;
-    parking: Array<StopPlaceFacilitiesParking>;
+    stopPlace: Array<StopPlaceFacilitiesStopPlace>
+    parking: Array<StopPlaceFacilitiesParking>
 }


### PR DESCRIPTION
Prettier har litt andre default-verdiar i v2. Dei forklarar desse her: https://prettier.io/blog/2020/03/21/2.0.0.html

Det som er tydelegast hos oss er at arrow functions med 1 parameter får parentes rundt parameteret. Eg synst dette er veldig riktig, og Prettier-bloggen forklarar fordelane godt:

> At first glance, avoiding parentheses in the isolated example above may look like a better choice because it results in less visual noise. However, when Prettier removes parentheses, it becomes harder to add type annotations, extra arguments, default values, or a variety of other things. Consistent use of parentheses provides a better developer experience when editing real codebases, which justifies the change.