### PR TITLE
Retry calls once if 429 Too Frequent Requests – Spike Arrest

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -9,6 +9,27 @@ const DEFAULT_HEADERS = {
     'Content-Type': 'application/json',
 }
 
+function delayedPromise<T>(
+    callback: () => Promise<T>,
+    delay: number,
+): Promise<T> {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => callback().then(resolve).catch(reject), delay)
+    })
+}
+
+function retryIfNecessary(
+    response: Response,
+    call: () => Promise<Response>,
+): Response | PromiseLike<Response> {
+    if (response.status !== 429) {
+        return response
+    }
+
+    const delay = Math.floor(Math.random() * 200)
+    return delayedPromise(call, delay)
+}
+
 function responseHandler(response: Response): Response | PromiseLike<Response> {
     if (!response.ok) {
         throw Error(response.statusText)
@@ -28,11 +49,15 @@ export function get<T extends object>(
 ): Promise<T> {
     const fetcher = customFetch || fetch
 
-    return fetcher(`${url}?${qs.stringify(params)}`, {
-        method: 'get',
-        ...config,
-        headers: { ...DEFAULT_HEADERS, ...headers },
-    })
+    const call = (): Promise<Response> =>
+        fetcher(`${url}?${qs.stringify(params)}`, {
+            method: 'get',
+            ...config,
+            headers: { ...DEFAULT_HEADERS, ...headers },
+        })
+
+    return call()
+        .then((response) => retryIfNecessary(response, call))
         .then(responseHandler)
         .then((res) => res.json())
         .then((data) =>
@@ -52,12 +77,16 @@ export function post<T>(
 ): Promise<T> {
     const fetcher = customFetch || fetch
 
-    return fetcher(url, {
-        method: 'post',
-        ...config,
-        headers: { ...DEFAULT_HEADERS, ...headers },
-        body: JSON.stringify(params),
-    })
+    const call = (): Promise<Response> =>
+        fetcher(url, {
+            method: 'post',
+            ...config,
+            headers: { ...DEFAULT_HEADERS, ...headers },
+            body: JSON.stringify(params),
+        })
+
+    return call()
+        .then((response) => retryIfNecessary(response, call))
         .then(responseHandler)
         .then((res) => res.json())
         .then((data) =>


### PR DESCRIPTION
If you make a lot of parallel requests, you might get a spike arrest. With this change, calls are retried once if the response is of type 429 Too Many Requests, for a slightly smoother user experience.

The delay before retrying is a random value between 0 and 200 ms.

I don't think it's necessary to make a more sophisticated retry strategy with X number of retries and so on. If the consumer of the SDK is having problems with frequent 429, he/she should re-organize the code or use the throttler utility or something.