### PR TITLE
Add `advice` on Situation, `detail` is deprecated

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,8 @@ export interface Situation {
     situationNumber: string
     summary: Array<MultilingualString>
     description: Array<MultilingualString>
-    detail: Array<MultilingualString>
+    advice: Array<MultilingualString>
+    detail: Array<MultilingualString> // Deprecated! `advice` should be used instead.
     lines: Array<Line>
     validityPeriod: ValidityPeriod
     reportType: ReportType

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -193,7 +193,8 @@ type $entur$sdk$Situation = {|
     situationNumber: string,
     summary: Array<$entur$sdk$MultilingualString>,
     description: Array<$entur$sdk$MultilingualString>,
-    detail: Array<$entur$sdk$MultilingualString>,
+    advice: Array<$entur$sdk$MultilingualString>,
+    detail: Array<$entur$sdk$MultilingualString>, // Deprecated! `advice` should be used instead.
     lines: Array<$entur$sdk$Line>,
     validityPeriod: $entur$sdk$ValidityPeriod,
     reportType: $entur$sdk$ReportType,

--- a/src/fields/Situation.ts
+++ b/src/fields/Situation.ts
@@ -14,7 +14,8 @@ export interface Situation {
     situationNumber: string
     summary: Array<MultilingualString>
     description: Array<MultilingualString>
-    detail: Array<MultilingualString>
+    advice: Array<MultilingualString>
+    detail: Array<MultilingualString> // Deprecated! `advice` should be used instead.
     lines: Array<Line>
     validityPeriod: {
         startTime: string
@@ -37,6 +38,10 @@ fragment ${fragmentName} on PtSituationElement {
         value
     }
     description {
+        language
+        value
+    }
+    advice {
         language
         value
     }


### PR DESCRIPTION
<img width="370" alt="image" src="https://user-images.githubusercontent.com/4339443/83517250-d9ab6100-a4d8-11ea-8049-9a8194cb95e1.png">

We should remove `detail` in the next major version of the SDK.