### PR TITLE
Add getScootersByPosition

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -44,7 +44,8 @@ The Entur SDK uses multiple endpoints for its services. Each endpoint can be ove
 ```javascript
 {
     journeyPlanner: '',
-    geocoder: ''
+    geocoder: '',
+    scooters: '',
 }
 ```
 

--- a/docs/scooters/getScootersByPosition.mdx
+++ b/docs/scooters/getScootersByPosition.mdx
@@ -1,0 +1,97 @@
+---
+name: getScootersByPosition
+menu: Scooters
+route: /bikes/getScootersByPosition
+---
+
+# getScootersByPosition
+
+```typescript
+(params: GetScootersByPositionParams) => Promise<Scooter[]>
+```
+
+`getScooters` finds scooters within an area surrounding a coordinate.
+
+This method uses the [Scooters API](https://developer.entur.org/pages-mobility-docs-scooters).
+
+## Parameters
+
+### params (`Object`)
+
+| Key         | Type                | Required? | Default | Description |
+|:------------|:--------------------|:----------|:--------|
+| `latitude`  | `number`            | `true`    | N/A     | The latitude coordinate to find scooters around |
+| `longitude` | `number`            | `true`    | N/A     | The longitude coordinate to find scooters around |
+| `distance`  | `number`            | `false`   | 200     | The radius of the search area, surrounding the latitude/longitude coordinates |
+| `limit`     | `number`            | `false`   | 20      | The max number of scooters to return |
+| `operators` | `ScooterOperator[]` | `false`   |         | A list of operators to find scooters for. If not specified, all are returned. |
+
+## Example
+
+```javascript
+import createEnturService from '@entur/sdk'
+// or: const createEnturService = require('@entur/sdk').default
+
+const service = createEnturService({
+    clientName: 'awesomecompany-awesomeapp'
+})
+
+async function example() {
+    try {
+        const scooters = await service.getScootersByPosition(
+            {
+                latitude: 59.95,
+                longitude: 10.75,
+                distance: 200,
+                limit: 10,
+                operators: ['TIER', 'VOI'], // Use the ScooterOperator enum if using TypeScript
+            },
+        )
+        console.log(scooters)
+    } catch (error) {
+        console.error(error)
+    }
+}
+```
+
+## `battery` or `batteryLevel`?
+
+All operators except Lime provide the `battery` field, which is a number representing the remaining battery charge percentage.
+Lime scooters have a `batteryLevel` field, which is either `"LOW"`, `"MEDIUM"` or `"HIGH"`.
+
+We have explicitly typed this by making the `Scooter` type a union type of `BatteryScooter` and `BatteryLevelScooter`.
+The utility method `isBatteryScooter` and `isBatteryLevelScooter` can be used to refine the type, as shown in the example below:
+
+```typescript
+import createEnturService, { Scooter, isBatteryScooter, BatteryLevel } from '@entur/sdk'
+
+const service = createEnturService({
+    clientName: 'awesomecompany-awesomeapp'
+})
+
+async function averageBatteryPercentage(): Promise<number> {
+    const scooters = await service.getScootersByPosition({ latitude: 59.909, longitude: 10.746, limit: 1 })
+
+    const batteryPercentages: number[] = scooters.map(scooter => {
+        if (isBatteryScooter(scooter)) {
+            return scooter.battery
+        }
+
+        // TypeScript now knows that `scooter` is a `BatteryLevelScooter`, and that the operator must be ScooterOperators.LIME.
+
+        switch (scooter.batteryLevel) {
+            // The following are just approximations of percentages, not a necessarily the truth
+            case BatteryLevel.LOW:
+                return 20
+            case BatteryLevel.MEDIUM:
+                return 50
+            case BatteryLevel.HIGH:
+                return 80
+        }
+    })
+
+    return batteryPercentages.reduce((a, b) => a + b) / batteryPercentages.length
+}
+
+averageBatteryPercentage()
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,43 @@ export interface BikeRentalStation {
 }
 
 /**
+ * Scooters
+ */
+
+export enum ScooterOperator {
+    VOI = 'VOI',
+    TIER = 'TIER',
+    ZVIPP = 'ZVIPP',
+    LIME = 'LIME',
+}
+
+export type BatteryScooter = {
+    id: string
+    lat: number
+    lon: number
+    code?: string
+    operator: ScooterOperator.VOI | ScooterOperator.TIER | ScooterOperator.ZVIPP
+    battery: number
+}
+
+export enum BatteryLevel {
+    LOW = 'LOW',
+    MEDIUM = 'MEDIUM',
+    HIGH = 'HIGH',
+}
+
+export type BatteryLevelScooter = {
+    id: string
+    lat: number
+    lon: number
+    code?: string
+    operator: ScooterOperator.LIME
+    batteryLevel: BatteryLevel
+}
+
+export type Scooter = BatteryScooter | BatteryLevelScooter
+
+/**
  * Geocoder
  */
 
@@ -739,6 +776,14 @@ export interface EnturService {
         coordinates: Coordinates,
         distance?: number,
     ) => Promise<BikeRentalStation[]>
+
+    getScootersByPosition: (params: {
+        latitude: number
+        longitude: number
+        distance?: number
+        limit?: number
+        operators?: ScooterOperator[]
+    }) => Promise<Scooter[]>
 }
 
 export default function createEnturService(config: Config): EnturService
@@ -916,3 +961,8 @@ export function isTransit(mode: string): boolean
 export function isFoot(mode: string): boolean
 export function isCarPark(mode: string): boolean
 export function isCarPickup(mode: string): boolean
+
+export function isBatteryScooter(scooter: Scooter): scooter is BatteryScooter
+export function isBatteryLevelScooter(
+    scooter: Scooter,
+): scooter is BatteryLevelScooter

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -217,6 +217,35 @@ type $entur$sdk$BikeRentalStation = {
 }
 
 /**
+ * Scooters
+ */
+
+type $entur$sdk$ScooterOperator = 'VOI' | 'LIME' | 'TIER' | 'ZVIPP'
+
+type $entur$sdk$BaseScooter = {|
+    id: string,
+    lat: number,
+    lon: number,
+    code?: string,
+|}
+
+type $entur$sdk$BatteryScooter = {|
+    ...$entur$sdk$BaseScooter,
+    operator: 'VOI' | 'TIER' | 'ZVIPP',
+    battery: number,
+|}
+
+type $entur$sdk$BatteryLevel = 'LOW' | 'MEDIUM' | 'HIGH'
+
+type $entur$sdk$BatteryLevelScooter = {|
+    ...$entur$sdk$BaseScooter,
+    operator: 'LIME',
+    batteryLevel: $entur$sdk$BatteryLevel,
+|}
+
+type $entur$sdk$Scooter = $entur$sdk$BatteryScooter | $entur$sdk$BatteryLevelScooter
+
+/**
  * Geocoder
  */
 
@@ -743,6 +772,14 @@ declare module '@entur/sdk' {
             coordinates: $entur$sdk$Coordinates,
             distance?: number
         ) => Promise<Array<$entur$sdk$BikeRentalStation>>,
+
+        getScootersByPosition: (params: {
+            latitude: number,
+            longitude: number,
+            distance?: number,
+            limit?: number,
+            operators?: $entur$sdk$ScooterOperator[],
+        }) => Promise<$entur$sdk$Scooter[]>
     |}
 
     declare export default function createEnturService(config: $entur$sdk$Config): EnturService
@@ -902,4 +939,10 @@ declare module '@entur/sdk' {
     declare export function isFoot(mode: string): boolean
     declare export function isCarPark(mode: string): boolean
     declare export function isCarPickup(mode: string): boolean
+
+    declare export function isBatteryScooter(scooter: $entur$sdk$Scooter): boolean
+    declare export function isBatteryLevelScooter(
+        scooter: $entur$sdk$Scooter,
+    ): boolean
+
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,7 @@ export interface ServiceConfig {
         journeyPlanner: string
         geocoder: string
         nsr: string
+        scooters: string
     }
     headers: { [key: string]: string }
     fetch?: (
@@ -25,6 +26,7 @@ export interface ArgumentConfig {
         journeyPlanner?: string
         geocoder?: string
         nsr?: string
+        scooters?: string
     }
     headers?: { [key: string]: string }
     fetch?: (
@@ -39,6 +41,7 @@ export interface OverrideConfig {
         journeyPlanner?: string
         geocoder?: string
         nsr?: string
+        scooters?: string
     }
     headers?: { [key: string]: string }
     fetch?: (
@@ -51,6 +54,7 @@ const HOST_CONFIG = {
     journeyPlanner: 'https://api.entur.io/journey-planner/v2',
     geocoder: 'https://api.entur.io/geocoder/v1',
     nsr: 'https://api.entur.io/stop-places/v1',
+    scooters: 'https://api.entur.io/mobility/v1/scooters',
 }
 
 export function getServiceConfig(config: ArgumentConfig): ServiceConfig {
@@ -109,6 +113,20 @@ export function getNSRHost({
 }: ServiceConfig): HostConfig {
     return {
         host: hosts.nsr,
+        headers: {
+            'ET-Client-Name': clientName,
+            ...headers,
+        },
+    }
+}
+
+export function getScootersHost({
+    hosts,
+    clientName,
+    headers,
+}: ServiceConfig): HostConfig {
+    return {
+        host: hosts.scooters,
         headers: {
             'ET-Client-Name': clientName,
             ...headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from './utils'
 
 export { getTripPatternsQuery } from './trip'
+export { isBatteryScooter, isBatteryLevelScooter } from './scooters'
 
 export * from './constants/travelModes'
 export * from './constants/featureCategory'

--- a/src/scooters/index.ts
+++ b/src/scooters/index.ts
@@ -1,0 +1,57 @@
+import { get } from '../http'
+import {
+    Scooter,
+    ScooterOperator,
+    BatteryScooter,
+    BatteryLevelScooter,
+} from '../../types/Scooter'
+import { getServiceConfig, getScootersHost, ArgumentConfig } from '../config'
+
+const ALL_OPERATORS = Object.values(ScooterOperator)
+
+interface GetScootersByPositionParams {
+    latitude: number
+    longitude: number
+    distance?: number
+    limit?: number
+    operators?: ScooterOperator[]
+}
+
+export function createGetScootersByPosition(argConfig: ArgumentConfig) {
+    const config = getServiceConfig(argConfig)
+    const { host, headers } = getScootersHost(config)
+
+    return function getScootersByPosition(
+        params: GetScootersByPositionParams,
+    ): Promise<Scooter[]> {
+        const {
+            latitude: lat,
+            longitude: lon,
+            distance: range = 200,
+            limit: max = 20,
+            operators = ALL_OPERATORS,
+        } = params
+
+        return get<Scooter[]>(
+            host,
+            {
+                lat,
+                lon,
+                range,
+                max,
+                operators: operators.join(','),
+            },
+            headers,
+        ).then((data) => data || [])
+    }
+}
+
+export function isBatteryScooter(scooter: Scooter): scooter is BatteryScooter {
+    return 'battery' in scooter
+}
+
+export function isBatteryLevelScooter(
+    scooter: Scooter,
+): scooter is BatteryLevelScooter {
+    return 'batteryLevel' in scooter
+}

--- a/src/service.ts
+++ b/src/service.ts
@@ -28,6 +28,8 @@ import {
     createGetBikeRentalStationsByPosition,
 } from './bikeRental'
 
+import { createGetScootersByPosition } from './scooters'
+
 import { createGetFeatures, createGetFeaturesReverse } from './geocoder'
 
 import { ArgumentConfig, getServiceConfig, ServiceConfig } from './config'
@@ -89,6 +91,7 @@ function createEnturService(config: ArgumentConfig) {
         getBikeRentalStationsByPosition: createGetBikeRentalStationsByPosition(
             config,
         ),
+        getScootersByPosition: createGetScootersByPosition(config),
     }
 }
 

--- a/types/Scooter.ts
+++ b/types/Scooter.ts
@@ -1,0 +1,31 @@
+export enum ScooterOperator {
+    VOI = 'VOI',
+    TIER = 'TIER',
+    ZVIPP = 'ZVIPP',
+    LIME = 'LIME',
+}
+
+interface BaseScooter {
+    id: string
+    lat: number
+    lon: number
+    code?: string
+}
+
+export interface BatteryScooter extends BaseScooter {
+    operator: ScooterOperator.VOI | ScooterOperator.TIER | ScooterOperator.ZVIPP
+    battery: number
+}
+
+enum BatteryLevel {
+    LOW = 'LOW',
+    MEDIUM = 'MEDIUM',
+    HIGH = 'HIGH',
+}
+
+export interface BatteryLevelScooter extends BaseScooter {
+    operator: ScooterOperator.LIME
+    batteryLevel: BatteryLevel
+}
+
+export type Scooter = BatteryScooter | BatteryLevelScooter


### PR DESCRIPTION
Integrerer [Scooters-APIet](https://developer.entur.org/pages-mobility-docs-scooters) i SDKen.

SDKen setter eksplisitt default `operators`. Dette er ein whitelist. Default er alle støtta operatørar i dag. Sidan denne whitelisten blir eksplisitt satt, så vil det ikkje plutselig dukke opp nye operatørar dersom det blir lagt til APIet. Oppgradering av SDKen må då til for å få med seg ny operatør. Dette lar oss type Scooters-typane veldig detaljert.

Ein scooter er enten `BatteryScooter` eller `BatteryLevelScooter` (Lime). Dei har litt ulik type. Dette er typa som union-type, og det er lagt ved eit par utils (`isBatteryScooter`/`isBatteryLevelScooter`) for å kunne skille mellom desse (type guards i TypeScript).