### PR TITLE
FeatureCategory TS enum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -933,6 +933,7 @@ export var TransportSubmode: {
     CITY_TRAM: 'cityTram'
 }
 
+// @deprecated: Use the FeatureCategory enum instead of individual exports
 export var ONSTREET_BUS: 'onstreetBus'
 export var ONSTREET_TRAM: 'onstreetTram'
 export var AIRPORT: 'airport'
@@ -954,27 +955,27 @@ export var TETTSTEDDEL: 'tettsteddel'
 export var BYDEL: 'bydel'
 export var OTHER: 'other'
 
-export var FeatureCategory: {
-    ONSTREET_BUS: 'onstreetBus'
-    ONSTREET_TRAM: 'onstreetTram'
-    AIRPORT: 'airport'
-    RAIL_STATION: 'railStation'
-    METRO_STATION: 'metroStation'
-    BUS_STATION: 'busStation'
-    COACH_STATION: 'coachStation'
-    TRAM_STATION: 'tramStation'
-    HARBOUR_PORT: 'harbourPort'
-    FERRY_PORT: 'ferryPort'
-    FERRY_STOP: 'ferryStop'
-    LIFT_STATION: 'liftStation'
-    VEHICLE_RAIL_INTERCHANGE: 'vehicleRailInterchange'
-    GROUP_OF_STOP_PLACES: 'GroupOfStopPlaces'
-    POI: 'poi'
-    VEGADRESSE: 'Vegadresse'
-    STREET: 'street'
-    TETTSTEDDEL: 'tettsteddel'
-    BYDEL: 'bydel'
-    OTHER: 'other'
+declare enum FeatureCategory {
+    ONSTREET_BUS = 'onstreetBus',
+    ONSTREET_TRAM = 'onstreetTram',
+    AIRPORT = 'airport',
+    RAIL_STATION = 'railStation',
+    METRO_STATION = 'metroStation',
+    BUS_STATION = 'busStation',
+    COACH_STATION = 'coachStation',
+    TRAM_STATION = 'tramStation',
+    HARBOUR_PORT = 'harbourPort',
+    FERRY_PORT = 'ferryPort',
+    FERRY_STOP = 'ferryStop',
+    LIFT_STATION = 'liftStation',
+    VEHICLE_RAIL_INTERCHANGE = 'vehicleRailInterchange',
+    GROUP_OF_STOP_PLACES = 'GroupOfStopPlaces',
+    POI = 'poi',
+    VEGADRESSE = 'Vegadresse',
+    STREET = 'street',
+    TETTSTEDDEL = 'tettsteddel',
+    BYDEL = 'bydel',
+    OTHER = 'other',
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -136,6 +136,7 @@ export type Scooter = BatteryScooter | BatteryLevelScooter
  * Geocoder
  */
 
+// @deprecated. Use FeatureCategory enum instead
 export type Category =
     | 'onstreetBus'
     | 'onstreetTram'
@@ -248,7 +249,7 @@ export interface Feature {
         accuracy: 'point'
         layer: 'venue' | 'address'
         borough_gid: string
-        category: Category[]
+        category: FeatureCategory[]
         country_gid: string
         county: string
         county_gid: string

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -887,6 +887,7 @@ declare module '@entur/sdk' {
         CITY_TRAM: 'cityTram',
     }
 
+    // @deprecated: Use the FeatureCategory enum instead of individual exports
     declare export var ONSTREET_BUS: 'onstreetBus'
     declare export var ONSTREET_TRAM: 'onstreetTram'
     declare export var AIRPORT: 'airport'

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -253,7 +253,7 @@ type $entur$sdk$Scooter = $entur$sdk$BatteryScooter | $entur$sdk$BatteryLevelSco
  * Geocoder
  */
 
-type $entur$sdk$Category =
+type $entur$sdk$FeatureCategory =
     | 'onstreetBus'
     | 'onstreetTram'
     | 'airport'
@@ -274,6 +274,9 @@ type $entur$sdk$Category =
     | 'street'
     | 'tettsteddel'
     | 'bydel'
+
+// @deprecated. Use FeatureCategory instead
+type $entur$sdk$Category = $entur$sdk$FeatureCategory
 
 type $entur$sdk$GetFeaturesParams = {
     // @deprecated Use `boundary` object instead
@@ -325,7 +328,7 @@ type $entur$sdk$Feature = {
         accuracy: 'point',
         layer: 'venue' | 'address',
         borough_gid: string,
-        category: Array<$entur$sdk$Category>,
+        category: Array<$entur$sdk$FeatureCategory>,
         country_gid: string,
         county: string,
         county_gid: string,

--- a/src/constants/featureCategory.ts
+++ b/src/constants/featureCategory.ts
@@ -1,3 +1,4 @@
+// @deprecated: Use the FeatureCategory enum instead of individual exports
 export const ONSTREET_BUS = 'onstreetBus'
 export const ONSTREET_TRAM = 'onstreetTram'
 export const AIRPORT = 'airport'
@@ -19,25 +20,25 @@ export const TETTSTEDDEL = 'tettsteddel'
 export const BYDEL = 'bydel'
 export const OTHER = 'other'
 
-export const FeatureCategory = {
-    ONSTREET_BUS,
-    ONSTREET_TRAM,
-    AIRPORT,
-    RAIL_STATION,
-    METRO_STATION,
-    BUS_STATION,
-    COACH_STATION,
-    TRAM_STATION,
-    HARBOUR_PORT,
-    FERRY_PORT,
-    FERRY_STOP,
-    LIFT_STATION,
-    VEHICLE_RAIL_INTERCHANGE,
-    GROUP_OF_STOP_PLACES,
-    POI,
-    VEGADRESSE,
-    STREET,
-    TETTSTEDDEL,
-    BYDEL,
-    OTHER,
+export enum FeatureCategory {
+    ONSTREET_BUS = 'onstreetBus',
+    ONSTREET_TRAM = 'onstreetTram',
+    AIRPORT = 'airport',
+    RAIL_STATION = 'railStation',
+    METRO_STATION = 'metroStation',
+    BUS_STATION = 'busStation',
+    COACH_STATION = 'coachStation',
+    TRAM_STATION = 'tramStation',
+    HARBOUR_PORT = 'harbourPort',
+    FERRY_PORT = 'ferryPort',
+    FERRY_STOP = 'ferryStop',
+    LIFT_STATION = 'liftStation',
+    VEHICLE_RAIL_INTERCHANGE = 'vehicleRailInterchange',
+    GROUP_OF_STOP_PLACES = 'GroupOfStopPlaces',
+    POI = 'poi',
+    VEGADRESSE = 'Vegadresse',
+    STREET = 'street',
+    TETTSTEDDEL = 'tettsteddel',
+    BYDEL = 'bydel',
+    OTHER = 'other',
 }

--- a/src/types/Feature.ts
+++ b/src/types/Feature.ts
@@ -1,25 +1,4 @@
-/* eslint-disable camelcase */
-export type Category =
-    | 'onstreetBus'
-    | 'onstreetTram'
-    | 'airport'
-    | 'railStation'
-    | 'metroStation'
-    | 'busStation'
-    | 'coachStation'
-    | 'tramStation'
-    | 'harbourPort'
-    | 'ferryPort'
-    | 'ferryStop'
-    | 'liftStation'
-    | 'vehicleRailInterchange'
-    | 'other'
-    | 'GroupOfStopPlaces'
-    | 'poi'
-    | 'Vegadresse'
-    | 'street'
-    | 'tettsteddel'
-    | 'bydel'
+import { FeatureCategory } from '../constants/featureCategory'
 
 export type Feature = {
     geometry: {
@@ -34,7 +13,7 @@ export type Feature = {
         accuracy: 'point'
         layer: 'venue' | 'address'
         borough_gid: string
-        category: Category[]
+        category: FeatureCategory[]
         country_gid: string
         county: string
         county_gid: string


### PR DESCRIPTION
Export FeatureCategory as a TS enum instead of object, and use it for `category` property in `Feature`.