### PR TITLE
Fix missing exports of enums

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export {
 
 export { getTripPatternsQuery } from './trip'
 export { isBatteryScooter, isBatteryLevelScooter } from './scooters'
+export { ScooterOperator, BatteryLevel } from './scooters/types'
 
 export * from './constants/travelModes'
 export * from './constants/featureCategory'

--- a/src/scooters/types.ts
+++ b/src/scooters/types.ts
@@ -21,7 +21,7 @@ export interface BatteryScooter extends BaseScooter {
     battery: number
 }
 
-enum BatteryLevel {
+export enum BatteryLevel {
     LOW = 'LOW',
     MEDIUM = 'MEDIUM',
     HIGH = 'HIGH',


### PR DESCRIPTION
ScooterOperator og BatteryLevel må eksporterast for å kunne brukast som objekt og ikkje berre type.