### PR TITLE
Add regionalCarFerry to TransportSubMode type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -376,6 +376,7 @@ export type TransportSubmode =
     | 'airportLinkRail'
     | 'internationalCarFerry'
     | 'nationalCarFerry'
+    | 'regionalCarFerry'
     | 'localCarFerry'
     | 'internationalPassengerFerry'
     | 'localPassengerFerry'

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -65,6 +65,7 @@ type $entur$sdk$TransportSubmode =
     | 'airportLinkRail'
     | 'internationalCarFerry'
     | 'nationalCarFerry'
+    | 'regionalCarFerry'
     | 'localCarFerry'
     | 'internationalPassengerFerry'
     | 'localPassengerFerry'

--- a/src/types/Mode.ts
+++ b/src/types/Mode.ts
@@ -59,6 +59,7 @@ export type TransportSubmode =
     | 'internationalCarFerry'
     | 'nationalCarFerry'
     | 'localCarFerry'
+    | 'regionalCarFerry'
     | 'internationalPassengerFerry'
     | 'localPassengerFerry'
     | 'sightseeingService'


### PR DESCRIPTION
`regionalCarFerry` was used in TransportSubMode variable, but not in TransportSubMode type
