### PR TITLE
Remove deprecated 'detail' field, use 'advice' instead

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,6 @@ export interface Situation {
     summary: MultilingualString[]
     description: MultilingualString[]
     advice: MultilingualString[]
-    detail: MultilingualString[] // Deprecated! `advice` should be used instead.
     lines: Line[]
     validityPeriod: ValidityPeriod
     reportType: ReportType

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -198,7 +198,6 @@ type $entur$sdk$Situation = {|
     summary: Array<$entur$sdk$MultilingualString>,
     description: Array<$entur$sdk$MultilingualString>,
     advice: Array<$entur$sdk$MultilingualString>,
-    detail: Array<$entur$sdk$MultilingualString>, // Deprecated! `advice` should be used instead.
     lines: Array<$entur$sdk$Line>,
     validityPeriod: $entur$sdk$ValidityPeriod,
     reportType: $entur$sdk$ReportType,

--- a/src/fields/Situation.ts
+++ b/src/fields/Situation.ts
@@ -15,7 +15,6 @@ export interface Situation {
     summary: MultilingualString[]
     description: MultilingualString[]
     advice: MultilingualString[]
-    detail: MultilingualString[] // Deprecated! `advice` should be used instead.
     lines: Line[]
     validityPeriod: {
         startTime: string
@@ -42,10 +41,6 @@ fragment ${fragmentName} on PtSituationElement {
         value
     }
     advice {
-        language
-        value
-    }
-    detail {
         language
         value
     }


### PR DESCRIPTION
This is a breaking change that requires a major version bump.
Migration is easy, simply replace `detail` with `advice`.
With this change non-trip queries will work with OTP 2 as well.