### PR TITLE
Remove deprecated FeatureCategory constants, use enum instead

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -939,28 +939,6 @@ export var TransportSubmode: {
     CITY_TRAM: 'cityTram'
 }
 
-// @deprecated: Use the FeatureCategory enum instead of individual exports
-export var ONSTREET_BUS: 'onstreetBus'
-export var ONSTREET_TRAM: 'onstreetTram'
-export var AIRPORT: 'airport'
-export var RAIL_STATION: 'railStation'
-export var METRO_STATION: 'metroStation'
-export var BUS_STATION: 'busStation'
-export var COACH_STATION: 'coachStation'
-export var TRAM_STATION: 'tramStation'
-export var HARBOUR_PORT: 'harbourPort'
-export var FERRY_PORT: 'ferryPort'
-export var FERRY_STOP: 'ferryStop'
-export var LIFT_STATION: 'liftStation'
-export var VEHICLE_RAIL_INTERCHANGE: 'vehicleRailInterchange'
-export var GROUP_OF_STOP_PLACES: 'GroupOfStopPlaces'
-export var POI: 'poi'
-export var VEGADRESSE: 'Vegadresse'
-export var STREET: 'street'
-export var TETTSTEDDEL: 'tettsteddel'
-export var BYDEL: 'bydel'
-export var OTHER: 'other'
-
 declare enum FeatureCategory {
     ONSTREET_BUS = 'onstreetBus',
     ONSTREET_TRAM = 'onstreetTram',

--- a/libdef.flow.js
+++ b/libdef.flow.js
@@ -894,28 +894,6 @@ declare module '@entur/sdk' {
         CITY_TRAM: 'cityTram',
     }
 
-    // @deprecated: Use the FeatureCategory enum instead of individual exports
-    declare export var ONSTREET_BUS: 'onstreetBus'
-    declare export var ONSTREET_TRAM: 'onstreetTram'
-    declare export var AIRPORT: 'airport'
-    declare export var RAIL_STATION: 'railStation'
-    declare export var METRO_STATION: 'metroStation'
-    declare export var BUS_STATION: 'busStation'
-    declare export var COACH_STATION: 'coachStation'
-    declare export var TRAM_STATION: 'tramStation'
-    declare export var HARBOUR_PORT: 'harbourPort'
-    declare export var FERRY_PORT: 'ferryPort'
-    declare export var FERRY_STOP: 'ferryStop'
-    declare export var LIFT_STATION: 'liftStation'
-    declare export var VEHICLE_RAIL_INTERCHANGE: 'vehicleRailInterchange'
-    declare export var GROUP_OF_STOP_PLACES: 'GroupOfStopPlaces'
-    declare export var POI: 'poi'
-    declare export var VEGADRESSE: 'Vegadresse'
-    declare export var STREET: 'street'
-    declare export var TETTSTEDDEL: 'tettsteddel'
-    declare export var BYDEL: 'bydel'
-    declare export var OTHER: 'other'
-
     declare export var FeatureCategory: {
         ONSTREET_BUS: 'onstreetBus',
         ONSTREET_TRAM: 'onstreetTram',

--- a/src/constants/featureCategory.ts
+++ b/src/constants/featureCategory.ts
@@ -1,25 +1,3 @@
-// @deprecated: Use the FeatureCategory enum instead of individual exports
-export const ONSTREET_BUS = 'onstreetBus'
-export const ONSTREET_TRAM = 'onstreetTram'
-export const AIRPORT = 'airport'
-export const RAIL_STATION = 'railStation'
-export const METRO_STATION = 'metroStation'
-export const BUS_STATION = 'busStation'
-export const COACH_STATION = 'coachStation'
-export const TRAM_STATION = 'tramStation'
-export const HARBOUR_PORT = 'harbourPort'
-export const FERRY_PORT = 'ferryPort'
-export const FERRY_STOP = 'ferryStop'
-export const LIFT_STATION = 'liftStation'
-export const VEHICLE_RAIL_INTERCHANGE = 'vehicleRailInterchange'
-export const GROUP_OF_STOP_PLACES = 'GroupOfStopPlaces'
-export const POI = 'poi'
-export const VEGADRESSE = 'Vegadresse'
-export const STREET = 'street'
-export const TETTSTEDDEL = 'tettsteddel'
-export const BYDEL = 'bydel'
-export const OTHER = 'other'
-
 export enum FeatureCategory {
     ONSTREET_BUS = 'onstreetBus',
     ONSTREET_TRAM = 'onstreetTram',


### PR DESCRIPTION
Breaking change, needs major version bump.
Migration is easy, use enum instead of individual constants:
```diff
-import { ONSTREET_BUS } from '@entur/sdk'
+import { FeatureCategory } from '@entur/sdk'

-console.log(ONSTREET_BUS)
+console.log(FeatureCategory.ONSTREET_BUS)
```