### PR TITLE
Separate EstimatedCall and Departure types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -396,8 +396,36 @@ export interface DestinationDisplay {
 }
 
 export interface EstimatedCall {
-    actualArrivalTime?: string // Only available AFTER arrival has taken place
-    actualDepartureTime?: string // Only available AFTER departure has taken place
+    /** Only available AFTER arrival has taken place */
+    actualArrivalTime?: string
+    /** Only available AFTER departure has taken place */
+    actualDepartureTime?: string
+    aimedArrivalTime: string
+    aimedDepartureTime: string
+    cancellation: boolean
+    date: string
+    destinationDisplay: DestinationDisplay
+    expectedArrivalTime: string
+    expectedDepartureTime: string
+    forAlighting: boolean
+    forBoarding: boolean
+    notices?: Notice[]
+    predictionInaccurate: boolean
+    quay?: Quay
+    realtime: boolean
+    requestStop: boolean
+    serviceJourney: ServiceJourney
+    /** @deprecated Use leg.situations or getDeparturesXxx methods */
+    situations?: Situation[]
+}
+
+export type IntermediateEstimatedCall = EstimatedCall
+
+export interface Departure {
+    /** Only available AFTER arrival has taken place */
+    actualArrivalTime?: string
+    /** Only available AFTER departure has taken place */
+    actualDepartureTime?: string
     aimedArrivalTime: string
     aimedDepartureTime: string
     cancellation: boolean
@@ -415,10 +443,6 @@ export interface EstimatedCall {
     serviceJourney: ServiceJourney
     situations: Situation[]
 }
-
-export type IntermediateEstimatedCall = EstimatedCall
-
-export type Departure = EstimatedCall
 
 export type BookingMethod = 'callOffice' | 'online'
 

--- a/src/departure/mapper.ts
+++ b/src/departure/mapper.ts
@@ -1,10 +1,14 @@
-import { EstimatedCall } from '../fields/EstimatedCall'
+import { Departure } from '../fields/Departure'
 import { Leg } from '../fields/Leg'
 import { Notice } from '../fields/Notice'
 
 import { uniqBy } from '../utils'
 
-function getNoticesFromLeg(leg: Leg): Notice[] {
+export interface LegWithDepartures extends Leg {
+    fromEstimatedCall?: Departure
+}
+
+function getNoticesFromLeg(leg: LegWithDepartures): Notice[] {
     const notices = [
         ...(leg.serviceJourney?.notices || []),
         ...(leg.serviceJourney?.journeyPattern?.notices || []),
@@ -14,7 +18,7 @@ function getNoticesFromLeg(leg: Leg): Notice[] {
     return uniqBy(notices, (notice) => notice.text)
 }
 
-function getNotices(departure: EstimatedCall): Notice[] {
+function getNotices(departure: Departure): Notice[] {
     const notices = [
         ...(departure.notices || []),
         ...(departure.serviceJourney?.notices || []),
@@ -24,14 +28,16 @@ function getNotices(departure: EstimatedCall): Notice[] {
     return uniqBy(notices, (notice) => notice.text)
 }
 
-export function destinationMapper(departure: EstimatedCall): EstimatedCall {
+export function destinationMapper(departure: Departure): Departure {
     return {
         ...departure,
         notices: getNotices(departure),
     }
 }
 
-export function legToDepartureMapper(leg: Leg): EstimatedCall | undefined {
+export function legToDepartureMapper(
+    leg: LegWithDepartures,
+): Departure | undefined {
     const { fromEstimatedCall } = leg
 
     if (!fromEstimatedCall) return undefined

--- a/src/departure/query.ts
+++ b/src/departure/query.ts
@@ -7,6 +7,7 @@ import {
     fragmentName as departureFields,
     fragments as departureFragments,
 } from '../fields/Departure'
+import { uniq } from '../utils'
 
 export const getDeparturesFromStopPlacesQuery = `
 query(
@@ -104,8 +105,7 @@ query(
     }
 }
 
-${departureFragments.join('')}
-${legFragments.join('')}
+${uniq<string>([...departureFragments, ...legFragments]).join('')}
 `
 
 export const getDeparturesForServiceJourneyQuery = `

--- a/src/departure/query.ts
+++ b/src/departure/query.ts
@@ -4,9 +4,9 @@ import {
 } from '../fields/Leg'
 
 import {
-    fragmentName as estimatedCallFields,
-    fragments as estimatedCallFragments,
-} from '../fields/EstimatedCall'
+    fragmentName as departureFields,
+    fragments as departureFragments,
+} from '../fields/Departure'
 
 export const getDeparturesFromStopPlacesQuery = `
 query(
@@ -36,12 +36,12 @@ query(
             whiteListedModes: $whiteListedModes,
             includeCancelledTrips: $includeCancelledTrips
         ) {
-            ...${estimatedCallFields}
+            ...${departureFields}
         }
     }
 }
 
-${estimatedCallFragments.join('')}
+${departureFragments.join('')}
 `
 
 export const getDeparturesFromQuayQuery = `
@@ -64,12 +64,12 @@ query(
             includeCancelledTrips: $includeCancelledTrips,
             numberOfDeparturesPerLineAndDestinationDisplay: $limitPerLine
         ) {
-            ...${estimatedCallFields}
+            ...${departureFields}
         }
     }
 }
 
-${estimatedCallFragments.join('')}
+${departureFragments.join('')}
 `
 
 export const getDeparturesBetweenStopPlacesQuery = `
@@ -96,11 +96,15 @@ query(
         tripPatterns {
             legs {
                 ...${legFields}
+                fromEstimatedCall {
+                    ...${departureFields}
+                }
             }
         }
     }
 }
 
+${departureFragments.join('')}
 ${legFragments.join('')}
 `
 
@@ -111,10 +115,10 @@ query(
 ) {
     serviceJourney(id: $id) {
         estimatedCalls(date: $date) {
-            ...${estimatedCallFields}
+            ...${departureFields}
         }
     }
 }
 
-${estimatedCallFragments.join('')}
+${departureFragments.join('')}
 `

--- a/src/fields/Departure.ts
+++ b/src/fields/Departure.ts
@@ -24,7 +24,7 @@ import {
     Situation,
 } from './Situation'
 
-export interface EstimatedCall {
+export interface Departure {
     actualArrivalTime?: string // Only available AFTER arrival has taken place
     actualDepartureTime?: string // Only available AFTER departure has taken place
     aimedArrivalTime: string
@@ -44,11 +44,8 @@ export interface EstimatedCall {
     realtime: boolean
     requestStop: boolean
     serviceJourney: ServiceJourney
-    /** @deprecated Use leg.situations or getDeparturesXxx methods */
-    situations?: Situation[]
+    situations: Situation[]
 }
-
-export type IntermediateEstimatedCall = EstimatedCall
 
 export const fragmentName = 'estimatedCallFields'
 


### PR DESCRIPTION
`Departure` har vore eit alias for `EstimatedCall`, men med dette blir dei separerte og får ein liten forskjell på `situations`-feltet.

Problemet her er at man spør om like mykje data på EstimatedCall i `trip`-kall (`getTripPatterns`) som på meir avgangsspesifikke kall (`getDeparturesXxx`-metodane). Dette fører til at responsen på `getTripPatterns` blir unødvendig stor. 

For eksempel blir `situations` aggregert på Leg-nivå, og å hente situations per `fromEstimatedCall`, `toEstimatedCall`, `intermediateEstimatedCalls`, er sjelden nyttig, sidan dei finst allereie på `leg.situations`.

Å fjerne situations frå EstimatedCall-typen er ein breaking change som krever ny major version. I denne PRen er dette ikkje gjort, men `EstimatedCall.situations` har fått deprecation-tag. Ønsket er å fjerne dette feltet i framtidig major-version.

## EstimatedCall.situations er blitt optional
For å hjelpe dei som bruker TypeScript, er situations satt til optional på EstimatedCall, sjølv om den faktisk alltid vil bli inkludert. Det kan jo diskurerast om det å endre typen til optional er ein breaking change sidan det kan kreve kodeendringar hos konsument, men eg meiner at det er verdt det å gi den ekstra oppmerksomheten rundt at dette feltet kjem til å forsvinne.

## Migrere vekk fra bruk av `leg.<from/to/intermediate>EstimatedCall.situations`?

I dei aller fleste tilfelle bør løysinga vere å bruke `leg.situations` direkte. Der er alle inkludert, pluss at den lista tar hensyn til gyldighetsperiode.

Man kan også bruke `getDepartures`-metodane dersom man vil ha utfyllande informasjon på avgangar. 
