### PR TITLE
Only ask for used types for getDeparturesBetweenStopPlaces

### DIFF
--- a/src/departure/mapper.ts
+++ b/src/departure/mapper.ts
@@ -1,11 +1,19 @@
 import { Departure } from '../fields/Departure'
-import { Leg } from '../fields/Leg'
 import { Notice } from '../fields/Notice'
+import { Place } from '../fields/Place'
+import { ServiceJourney } from '../fields/ServiceJourney'
+import { Situation } from '../fields/Situation'
 
 import { uniqBy } from '../utils'
 
-export interface LegWithDepartures extends Leg {
+export interface LegWithDepartures {
+    aimedStartTime: string
+    expectedStartTime: string
     fromEstimatedCall?: Departure
+    fromPlace: Place
+    realtime: boolean
+    serviceJourney: ServiceJourney
+    situations: Situation[]
 }
 
 function getNoticesFromLeg(leg: LegWithDepartures): Notice[] {

--- a/src/departure/query.ts
+++ b/src/departure/query.ts
@@ -1,12 +1,23 @@
 import {
-    fragmentName as legFields,
-    fragments as legFragments,
-} from '../fields/Leg'
+    fragmentName as quayFields,
+    fragments as quayFragments,
+} from '../fields/Quay'
+
+import {
+    fragmentName as serviceJourneyFields,
+    fragments as serviceJourneyFragments,
+} from '../fields/ServiceJourney'
 
 import {
     fragmentName as departureFields,
     fragments as departureFragments,
 } from '../fields/Departure'
+
+import {
+    fragmentName as situationFields,
+    fragments as situationFragments,
+} from '../fields/Situation'
+
 import { uniq } from '../utils'
 
 export const getDeparturesFromStopPlacesQuery = `
@@ -96,7 +107,20 @@ query(
     ) {
         tripPatterns {
             legs {
-                ...${legFields}
+                aimedStartTime
+                expectedStartTime
+                fromPlace {
+                    quay {
+                        ...${quayFields}
+                    }
+                }
+                realtime
+                serviceJourney {
+                    ...${serviceJourneyFields}
+                }
+                situations {
+                    ...${situationFields}
+                }
                 fromEstimatedCall {
                     ...${departureFields}
                 }
@@ -105,7 +129,12 @@ query(
     }
 }
 
-${uniq<string>([...departureFragments, ...legFragments]).join('')}
+${uniq<string>([
+    ...departureFragments,
+    ...quayFragments,
+    ...serviceJourneyFragments,
+    ...situationFragments,
+]).join('')}
 `
 
 export const getDeparturesForServiceJourneyQuery = `


### PR DESCRIPTION
The query for `getDeparturesBetweenStopPlaces` asked for many fields on Leg that weren't used. The `legToDepartureMapper` function only takes a certain set of fields from Leg and turns it into a Departure. With this change, only the fields used by the mapper are requested. This will lead to smaller network payloads and hopefully slightly faster calls.