### PR TITLE
V3 fixes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { Response } from 'node-fetch'
+import { Response, RequestInfo, RequestInit } from 'node-fetch'
 
 export interface HostConfig {
     host: string

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,6 @@
 import qs from 'qs'
 import cleanDeep from 'clean-deep'
-import { Response } from 'node-fetch'
+import { Response, RequestInfo, RequestInit } from 'node-fetch'
 
 import fetch from './fetch'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,16 @@ export {
 
 export { TypeName } from './nearest/types'
 export type { NearestPlace } from './nearest/types'
+
 export { getTripPatternsQuery } from './trip'
-export type { TripPattern } from './trip'
+export type {
+    TripPattern,
+    GetTripPatternsParams,
+    InputWhiteListed,
+    InputBanned,
+    TransportSubmodeParam,
+} from './trip'
+
 export { isBatteryScooter, isBatteryLevelScooter } from './scooters'
 export { ScooterOperator, BatteryLevel } from './scooters/types'
 export type { Scooter } from './scooters/types'

--- a/src/trip/index.ts
+++ b/src/trip/index.ts
@@ -45,12 +45,12 @@ export interface TripPattern {
     walkDistance: number
 }
 
-interface TransportSubmodeParam {
+export interface TransportSubmodeParam {
     transportMode: TransportMode
     transportSubmodes: TransportSubmode[]
 }
 
-interface InputBanned {
+export interface InputBanned {
     lines?: string[]
     authorities?: string[]
     organisations?: string[]
@@ -59,7 +59,7 @@ interface InputBanned {
     serviceJourneys?: string[]
 }
 
-interface InputWhiteListed {
+export interface InputWhiteListed {
     lines?: string[]
     authorities?: string[]
     organisations?: string[]

--- a/src/types/Mode.ts
+++ b/src/types/Mode.ts
@@ -9,7 +9,6 @@ export enum TransportMode {
     METRO = 'metro',
     RAIL = 'rail',
     TRAM = 'tram',
-    UNKNOWN = 'unknown',
     WATER = 'water',
 }
 
@@ -65,7 +64,6 @@ export enum LegMode {
     METRO = 'metro',
     RAIL = 'rail',
     TRAM = 'tram',
-    UNKNOWN = 'unknown',
     WATER = 'water',
 }
 


### PR DESCRIPTION
**Don't depend on browser-specific types**
RequestInfo and RequestInit require "DOM" in tsconfig lib
Using the types from node-fetch fixes type check for Node.js apps

**Export trip types that weren't exported.**

**Remove UNKNOWN Transport and Leg mode**
It will never actually exist.
