### PR TITLE
Add mobility.getVehicles method using the new Mobility v2 API

### DIFF
--- a/docs/mobility/getVehicles.mdx
+++ b/docs/mobility/getVehicles.mdx
@@ -1,0 +1,64 @@
+---
+name: getVehicles
+menu: Mobility
+route: /vehicles/getVehicles
+---
+
+# getVehicles
+
+```typescript
+(params: GetVehiclesParams, options?: RequestOptions) => Promise<Vehicle[]>
+```
+
+`getVehicles` finds micromobility vehicles, like e-scooters, shared bikes and cars, within an area surrounding set of coordinates.
+
+This method uses the `vehicles` query of the [Mobility v2 API](https://developer.entur.org/pages-mobility-docs-mobility-v2).
+
+## Parameters
+
+### params (`GetVehiclesParams`)
+
+| Key               | Type                | Required? | Default | Description                                                                   |
+| :---------------- | :------------------ | :-------- | :------ | ----------------------------------------------------------------------------- |
+| `lat`             |  `number`           | `true`    | N/A     | The latitude coordinate to find vehicles around                               |
+| `lon`             |  `number`           | `true`    | N/A     | The longitude coordinate to find vehicles around                              |
+| `range`           |  `number`           | `true`    | N/A     | The radius of the search area, surrounding the latitude/longitude coordinates |
+| `count`           |  `number`           | `false`   |         | The max number of vehicles to return                                          |
+| `operators`       |  `string[]`         | `false`   |         |                                                                               |
+| `codespaces`      |  `string[]`         | `false`   |         |                                                                               |
+| `formFactors`     |  `FormFactor[]`     | `false`   |         |                                                                               |
+| `propulsionTypes` |  `PropulsionType[]` | `false`   |         |                                                                               |
+| `includeReserved` |  `boolean`          | `false`   |         |                                                                               |
+| `includeDisabled` |  `boolean`          | `false`   |         |                                                                               |
+
+### options (`RequestOptions`) [Optional]
+
+An object containing a subset of `RequestInit` options that's applied to the request.
+
+| Key      | Type          | Description                                                                                                                                       |
+| :------- | :------------ | :------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `signal` | `AbortSignal` | Allows you to communicate with a fetch request and abort it if desired. [Read more](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) |
+
+## Example
+
+```javascript
+import createEnturService from '@entur/sdk'
+// or: const createEnturService = require('@entur/sdk').default
+
+const service = createEnturService({
+    clientName: 'awesomecompany-awesomeapp',
+})
+
+async function example() {
+    try {
+        const vehicles = await service.getVehicles({
+            lat: 59.95,
+            lon: 10.75,
+            range: 200,
+        })
+        console.log(vehicles)
+    } catch (error) {
+        console.error(error)
+    }
+}
+```

--- a/docs/mobility/getVehicles.mdx
+++ b/docs/mobility/getVehicles.mdx
@@ -7,7 +7,7 @@ route: /vehicles/getVehicles
 # getVehicles
 
 ```typescript
-(params: GetVehiclesParams, options?: RequestOptions) => Promise<Vehicle[]>
+(params: GetVehiclesParams, options?: RequestOptions) => Promise<MobilityTypes.Vehicle[]>
 ```
 
 `getVehicles` finds micromobility vehicles, like e-scooters, shared bikes and cars, within an area surrounding set of coordinates.
@@ -18,18 +18,18 @@ This method uses the `vehicles` query of the [Mobility v2 API](https://developer
 
 ### params (`GetVehiclesParams`)
 
-| Key               | Type                | Required? | Default | Description                                                                   |
-| :---------------- | :------------------ | :-------- | :------ | ----------------------------------------------------------------------------- |
-| `lat`             |  `number`           | `true`    | N/A     | The latitude coordinate to find vehicles around                               |
-| `lon`             |  `number`           | `true`    | N/A     | The longitude coordinate to find vehicles around                              |
-| `range`           |  `number`           | `true`    | N/A     | The radius of the search area, surrounding the latitude/longitude coordinates |
-| `count`           |  `number`           | `false`   |         | The max number of vehicles to return                                          |
-| `operators`       |  `string[]`         | `false`   |         |                                                                               |
-| `codespaces`      |  `string[]`         | `false`   |         |                                                                               |
-| `formFactors`     |  `FormFactor[]`     | `false`   |         |                                                                               |
-| `propulsionTypes` |  `PropulsionType[]` | `false`   |         |                                                                               |
-| `includeReserved` |  `boolean`          | `false`   |         |                                                                               |
-| `includeDisabled` |  `boolean`          | `false`   |         |                                                                               |
+| Key               | Type                | Required? | Default | Description                                                                    |
+| :---------------- | :------------------ | :-------- | :------ | ------------------------------------------------------------------------------ |
+| `lat`             |  `number`           | Yes       | N/A     | The latitude coordinate to find vehicles around.                               |
+| `lon`             |  `number`           | Yes       | N/A     | The longitude coordinate to find vehicles around.                              |
+| `range`           |  `number`           | Yes       | N/A     | The radius of the search area, surrounding the latitude/longitude coordinates. |
+| `count`           |  `number`           | No        |         | The max number of vehicles to return.                                          |
+| `operators`       |  `string[]`         | No        |         | Return only vehicles of the given operator IDs.                                |
+| `codespaces`      |  `string[]`         | No        |         | Return only vehicles of the given code spaces.                                 |
+| `formFactors`     |  `FormFactor[]`     | No        |         | Return only vehicles of the given forms, i.e. `FormFactor.SCOOTER`             |
+| `propulsionTypes` |  `PropulsionType[]` | No        |         | Return only vehicles of the given propulsion types.                            |
+| `includeReserved` |  `boolean`          | No        |         | Set to `true` to also include vehicles that have been reserved.                |
+| `includeDisabled` |  `boolean`          | No        |         | Set to `true` to also include vehicles that have been marked as disabled.      |
 
 ### options (`RequestOptions`) [Optional]
 
@@ -60,5 +60,75 @@ async function example() {
     } catch (error) {
         console.error(error)
     }
+}
+```
+
+## Example vehicle
+
+```
+{
+    lat: 59.967579,
+    lon: 10.732924,
+    pricingPlan: {
+        description: {
+            translation: [
+                {
+                    language: 'nb',
+                    value: 'Start 10 kroner, deretter 2.5 kroner per minutt',
+                },
+            ],
+        },
+        id: 'YVO:PricingPlan:Basic',
+        currency: 'NOK',
+        isTaxable: false,
+        name: {
+            translation: [
+                {
+                    language: 'nb',
+                    value: 'Basic',
+                },
+            ],
+        },
+        price: 10,
+        surgePricing: null,
+        url: null,
+    },
+    system: {
+        name: {
+            translation: [
+                {
+                    language: 'nb',
+                    value: 'VOI',
+                },
+            ],
+        },
+        email: null,
+        feedContactEmail: null,
+        id: 'YVO:System:voioslo',
+        licenseUrl: null,
+        language: 'nb',
+        phoneNumber: null,
+        operator: {
+            id: 'YVO:Operator:voi',
+            name: {
+                translation: [
+                    {
+                        language: 'nb',
+                        value: 'Voi',
+                    },
+                ],
+            },
+        },
+        purchaseUrl: null,
+        startDate: null,
+        shortName: null,
+        timezone: 'UTC',
+        url: null,
+    },
+    isDisabled: false,
+    isReserved: false,
+    id: 'YVO:Scooter:ec01560b-8b12-4cb8-ba50-68439c95dbe7',
+    currentRangeMeters: 0,
+    rentalUris: null,
 }
 ```

--- a/docs/mobility/getVehicles.mdx
+++ b/docs/mobility/getVehicles.mdx
@@ -51,7 +51,7 @@ const service = createEnturService({
 
 async function example() {
     try {
-        const vehicles = await service.getVehicles({
+        const vehicles = await service.mobility.getVehicles({
             lat: 59.95,
             lon: 10.75,
             range: 200,

--- a/doczrc.js
+++ b/doczrc.js
@@ -9,6 +9,7 @@ export default {
         'Travel',
         'Departures',
         'Places',
+        'Mobility',
         'Bikes',
         'Scooters',
         'Utils',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.6.0-rc.2",
+  "version": "3.6.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.6.0-rc.0",
+  "version": "3.6.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.5.0",
+  "version": "3.6.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.6.0-rc.1",
+  "version": "3.6.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.6.0-rc.1",
+  "version": "3.6.0-rc.2",
   "license": "EUPL-1.2",
   "main": "./lib/index.js",
   "repository": "github:entur/sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.5.0",
+  "version": "3.6.0-rc.0",
   "license": "EUPL-1.2",
   "main": "./lib/index.js",
   "repository": "github:entur/sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.6.0-rc.2",
+  "version": "3.6.0-rc.3",
   "license": "EUPL-1.2",
   "main": "./lib/index.js",
   "repository": "github:entur/sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entur/sdk",
-  "version": "3.6.0-rc.0",
+  "version": "3.6.0-rc.1",
   "license": "EUPL-1.2",
   "main": "./lib/index.js",
   "repository": "github:entur/sdk",

--- a/schemas/mobility.json
+++ b/schemas/mobility.json
@@ -161,9 +161,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TranslatedString",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -173,9 +177,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -185,9 +193,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -197,9 +209,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -209,9 +225,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "TranslatedString",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -276,9 +296,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -288,9 +312,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -300,9 +328,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -822,8 +854,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
+                  "kind": "OBJECT",
+                  "name": "TranslatedString",
                   "ofType": null
                 }
               },
@@ -919,9 +951,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -931,9 +967,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -943,9 +983,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -955,9 +999,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -967,9 +1015,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "System",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "System",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -979,12 +1031,16 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "LIST",
+                "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "PricingPlan",
-                  "ofType": null
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PricingPlan",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,
@@ -1051,8 +1107,8 @@
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
+                  "kind": "OBJECT",
+                  "name": "TranslatedString",
                   "ofType": null
                 }
               },
@@ -1064,8 +1120,8 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "TranslatedString",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -1076,8 +1132,8 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "TranslatedString",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -1203,6 +1259,80 @@
         },
         {
           "kind": "OBJECT",
+          "name": "TranslatedString",
+          "description": "",
+          "fields": [
+            {
+              "name": "translation",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Translation",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Translation",
+          "description": "",
+          "fields": [
+            {
+              "name": "language",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "value",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Vehicle",
           "description": "",
           "fields": [
@@ -1259,9 +1389,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1271,9 +1405,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1283,9 +1421,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "Float",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1295,9 +1437,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "VehicleType",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VehicleType",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1307,9 +1453,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "PricingPlan",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PricingPlan",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1331,9 +1481,13 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "System",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "System",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -1414,8 +1568,8 @@
               "description": "",
               "args": [],
               "type": {
-                "kind": "SCALAR",
-                "name": "String",
+                "kind": "OBJECT",
+                "name": "TranslatedString",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/schemas/mobility.json
+++ b/schemas/mobility.json
@@ -1,0 +1,2321 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "Built-in Boolean",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Float",
+          "description": "Built-in Float",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "FormFactor",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "BICYCLE",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CAR",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MOPED",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCOOTER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OTHER",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "Built-in ID",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "Built-in Int",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Operator",
+          "description": "",
+          "fields": [
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "codespace",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PricingPlan",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currency",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "price",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isTaxable",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "perKmPricing",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PricingSegment",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "perMinPricing",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PricingSegment",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "surgePricing",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PricingSegment",
+          "description": "",
+          "fields": [
+            {
+              "name": "start",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rate",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interval",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "end",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PropulsionType",
+          "description": "",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "HUMAN",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ELECTRIC_ASSIST",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ELECTRIC",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "COMBUSTION",
+              "description": "",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": "",
+          "fields": [
+            {
+              "name": "operators",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Operator",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "codespaces",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicles",
+              "description": "",
+              "args": [
+                {
+                  "name": "lat",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Float",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "lon",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Float",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "range",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "count",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "operators",
+                  "description": "",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "codespaces",
+                  "description": "",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "formFactors",
+                  "description": "",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "FormFactor",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "propulsionTypes",
+                  "description": "",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "PropulsionType",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "includeReserved",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                },
+                {
+                  "name": "includeDisabled",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Vehicle",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stations",
+              "description": "",
+              "args": [
+                {
+                  "name": "lat",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Float",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "lon",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Float",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "range",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "count",
+                  "description": "",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "operators",
+                  "description": "",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "codespaces",
+                  "description": "",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Station",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stationsById",
+              "description": "",
+              "args": [
+                {
+                  "name": "ids",
+                  "description": "",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Station",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RentalApp",
+          "description": "",
+          "fields": [
+            {
+              "name": "storeUri",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discoveryUri",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RentalApps",
+          "description": "",
+          "fields": [
+            {
+              "name": "ios",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RentalApp",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "android",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RentalApp",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "RentalUris",
+          "description": "",
+          "fields": [
+            {
+              "name": "android",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ios",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "web",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Station",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lat",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lon",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "address",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "capacity",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "numBikesAvailable",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "numDocksAvailable",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isInstalled",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isRenting",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isReturning",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastReported",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "system",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "System",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pricingPlans",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PricingPlan",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "Built-in String",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "System",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "language",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shortName",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "operator",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "purchaseUrl",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "startDate",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "phoneNumber",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "email",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feedContactEmail",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timezone",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "licenseUrl",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rentalApps",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RentalApps",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Vehicle",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lat",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lon",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isReserved",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDisabled",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentRangeMeters",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vehicleType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "VehicleType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pricingPlan",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PricingPlan",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "rentalUris",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "RentalUris",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "system",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "System",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VehicleType",
+          "description": "",
+          "fields": [
+            {
+              "name": "id",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "formFactor",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "FormFactor",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "propulsionType",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PropulsionType",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "maxRangeMeters",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Float",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": "",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "ENUM",
+                    "name": "__DirectiveLocation",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "onOperation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onFragment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            },
+            {
+              "name": "onField",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "Use `locations`."
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "An enum describing valid locations where a directive can be placed",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Indicates the directive is valid on queries.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Indicates the directive is valid on mutations.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Indicates the directive is valid on fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Indicates the directive is valid on fragment definitions.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Indicates the directive is valid on fragment spreads.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Indicates the directive is valid on inline fragments.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Indicates the directive is valid on a schema SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Indicates the directive is valid on a scalar SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates the directive is valid on an object SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Indicates the directive is valid on a field SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Indicates the directive is valid on a field argument SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates the directive is valid on an interface SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates the directive is valid on an union SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates the directive is valid on an enum SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Indicates the directive is valid on an enum value SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates the directive is valid on an input object SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Indicates the directive is valid on an input object field SDL definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": null,
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "'A list of all directives supported by this server.",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": null,
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given __Type is",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks the field or enum value as deprecated",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "The reason for the deprecation",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/scripts/fetch-schemas.ts
+++ b/scripts/fetch-schemas.ts
@@ -33,3 +33,9 @@ runIntrospectionQuery(
 ).then((schema) =>
     writeFile('schemas/nsr.json', JSON.stringify(schema, undefined, 2)),
 )
+
+runIntrospectionQuery(
+    'https://api.entur.io/mobility/v2/graphql',
+).then((schema) =>
+    writeFile('schemas/mobility.json', JSON.stringify(schema, undefined, 2)),
+)

--- a/scripts/fetch-schemas.ts
+++ b/scripts/fetch-schemas.ts
@@ -35,7 +35,7 @@ runIntrospectionQuery(
 )
 
 runIntrospectionQuery(
-    'https://api.entur.io/mobility/v2/graphql',
+    'https://api.dev.entur.io/mobility/v2/graphql',
 ).then((schema) =>
     writeFile('schemas/mobility.json', JSON.stringify(schema, undefined, 2)),
 )

--- a/scripts/validate-queries.js
+++ b/scripts/validate-queries.js
@@ -10,6 +10,7 @@ import { validate } from 'graphql/validation'
 
 import journeyplanner2SchemaJSON from '../schemas/journeyplanner2.json'
 import nsrSchemaJSON from '../schemas/nsr.json'
+import mobilitySchemaJSON from '../schemas/mobility.json'
 
 import {
     getBikeRentalStationQuery,
@@ -37,8 +38,11 @@ import {
 
 import { getTripPatternQuery } from '../src/trip/query'
 
+import getVehiclesQuery from '../src/mobility/getVehicles/query'
+
 const journeyplanner2Schema = buildClientSchema(journeyplanner2SchemaJSON.data)
 const nsrSchema = buildClientSchema(nsrSchemaJSON.data)
+const mobilitySchema = buildClientSchema(mobilitySchemaJSON.data)
 
 const jp2Queries = [
     { getBikeRentalStationQuery },
@@ -58,6 +62,8 @@ const jp2Queries = [
 ]
 
 const nsrQueries = [{ getStopPlaceFacilitiesQuery }]
+
+const mobilityQueries = [{ getVehiclesQuery }]
 
 function validateQuery(queryName, query, schema) {
     try {
@@ -80,6 +86,10 @@ function runValidations() {
     nsrQueries.forEach((obj) => {
         const [name, query] = Object.entries(obj)[0]
         validateQuery(name, query, nsrSchema)
+    })
+    mobilityQueries.forEach((obj) => {
+        const [name, query] = Object.entries(obj)[0]
+        validateQuery(name, query, mobilitySchema)
     })
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import { post, RequestOptions } from './http'
 
-import { getJourneyPlannerHost, getNSRHost } from './config'
+import { getJourneyPlannerHost, getMobilityHost, getNSRHost } from './config'
 import { ServiceConfig } from './config'
 
 function minify(query: string): string {
@@ -52,6 +52,23 @@ export function nsrQuery<T>(
     options?: RequestOptions,
 ): Promise<T> {
     const { host, headers } = getNSRHost(config)
+    const url = `${host}/graphql`
+
+    const params = {
+        query: minify(query),
+        variables,
+    }
+
+    return post(url, params, headers, config.fetch, options).then(errorHandler)
+}
+
+export function mobilityQuery<T>(
+    query: string,
+    variables: Record<string, any>,
+    config: ServiceConfig,
+    options?: RequestOptions,
+): Promise<T> {
+    const { host, headers } = getMobilityHost(config)
     const url = `${host}/graphql`
 
     const params = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ export interface ServiceConfig {
         geocoder: string
         nsr: string
         scooters: string
+        mobility: string
     }
     headers: { [key: string]: string }
     fetch?: (
@@ -27,6 +28,7 @@ export interface ArgumentConfig {
         geocoder?: string
         nsr?: string
         scooters?: string
+        mobility?: string
     }
     headers?: { [key: string]: string }
     fetch?: (
@@ -42,6 +44,7 @@ export interface OverrideConfig {
         geocoder?: string
         nsr?: string
         scooters?: string
+        mobility?: string
     }
     headers?: { [key: string]: string }
     fetch?: (
@@ -55,6 +58,7 @@ const HOST_CONFIG = {
     geocoder: 'https://api.entur.io/geocoder/v1',
     nsr: 'https://api.entur.io/stop-places/v1',
     scooters: 'https://api.entur.io/mobility/v1/scooters',
+    mobility: 'https://api.entur.io/mobility/v2',
 }
 
 export function getServiceConfig(config: ArgumentConfig): ServiceConfig {
@@ -127,6 +131,20 @@ export function getScootersHost({
 }: ServiceConfig): HostConfig {
     return {
         host: hosts.scooters,
+        headers: {
+            'ET-Client-Name': clientName,
+            ...headers,
+        },
+    }
+}
+
+export function getMobilityHost({
+    hosts,
+    clientName,
+    headers,
+}: ServiceConfig): HostConfig {
+    return {
+        host: hosts.mobility,
         headers: {
             'ET-Client-Name': clientName,
             ...headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,7 @@ export {
     throttler,
 } from './utils'
 
-export { FormFactor, PropulsionType } from './mobility/types'
-
 export * as MobilityTypes from './mobility/types'
-export type { GetVehiclesParams } from './mobility/getVehicles'
 
 export { TypeName } from './nearest/types'
 export type { NearestPlace } from './nearest/types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type {
     System,
     Vehicle,
 } from './mobility/types'
+export type { GetVehiclesParams } from './mobility/getVehicles'
 
 export { TypeName } from './nearest/types'
 export type { NearestPlace } from './nearest/types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,18 @@ export {
     throttler,
 } from './utils'
 
+export { FormFactor, PropulsionType } from './mobility/types'
+export type {
+    VehicleType,
+    PricingSegment,
+    PricingPlan,
+    RentalUris,
+    RentalApp,
+    RentalApps,
+    System,
+    Vehicle,
+} from './mobility/types'
+
 export { TypeName } from './nearest/types'
 export type { NearestPlace } from './nearest/types'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export type {
     RentalApp,
     RentalApps,
     System,
+    TranslatedString,
+    Translation,
     Vehicle,
 } from './mobility/types'
 export type { GetVehiclesParams } from './mobility/getVehicles'

--- a/src/mobility/getVehicles/index.ts
+++ b/src/mobility/getVehicles/index.ts
@@ -26,13 +26,13 @@ export default function createGetVehicles(argConfig: ArgumentConfig) {
         params: GetVehiclesParams,
         options?: RequestOptions,
     ): Promise<Vehicle[]> {
-        const data = await mobilityQuery<Vehicle[]>(
+        const data = await mobilityQuery<{ vehicles: Vehicle[] }>(
             getVehiclesQuery,
             params,
             config,
             options,
         )
 
-        return data || []
+        return data?.vehicles || []
     }
 }

--- a/src/mobility/getVehicles/index.ts
+++ b/src/mobility/getVehicles/index.ts
@@ -7,15 +7,25 @@ import { FormFactor, PropulsionType, Vehicle } from '../types'
 import getVehiclesQuery from './query'
 
 export interface GetVehiclesParams {
+    /** The latitude coordinate. */
     lat: number
+    /** The longitude coordinate. */
     lon: number
+    /** The radius in meters from the coordinate pair in which to find vehicles. */
     range: number
+    /** The maximum number of vehicles to return. */
     count?: number
+    /** Return only vehicles of the given operators.  */
     operators?: string[]
+    /** The maximum number of vehicles to return */
     codespaces?: string[]
+    /** Return only vehicles of the given form factors. */
     formFactors?: FormFactor[]
+    /** Return only vehicles of the given propulsion types. */
     propulsionTypes?: PropulsionType[]
+    /** Whether you want to return vehicles that are already reserved. The default is false. */
     includeReserved?: boolean
+    /** Whether you want to return vehicles that are disabled. The default is false. */
     includeDisabled?: boolean
 }
 

--- a/src/mobility/getVehicles/index.ts
+++ b/src/mobility/getVehicles/index.ts
@@ -1,0 +1,38 @@
+import { RequestOptions } from '../../http'
+import { getServiceConfig, ArgumentConfig } from '../../config'
+import { mobilityQuery } from '../../api'
+
+import { FormFactor, PropulsionType, Vehicle } from '../types'
+
+import getVehiclesQuery from './query'
+
+export interface GetVehiclesParams {
+    lat: number
+    lon: number
+    range: number
+    count?: number
+    operators?: string[]
+    codespaces?: string[]
+    formFactors?: FormFactor[]
+    propulsionTypes?: PropulsionType[]
+    includeReserved?: boolean
+    includeDisabled?: boolean
+}
+
+export default function createGetVehicles(argConfig: ArgumentConfig) {
+    const config = getServiceConfig(argConfig)
+
+    return async function getVehicles(
+        params: GetVehiclesParams,
+        options?: RequestOptions,
+    ): Promise<Vehicle[]> {
+        const data = await mobilityQuery<Vehicle[]>(
+            getVehiclesQuery,
+            params,
+            config,
+            options,
+        )
+
+        return data || []
+    }
+}

--- a/src/mobility/getVehicles/query.ts
+++ b/src/mobility/getVehicles/query.ts
@@ -1,0 +1,53 @@
+export default `
+query ($lat: Float!, $lon: Float!, $range: Int!, $count: Int, $operators: [String], $codespaces: [String], $formFactors: [FormFactor], $propulsionTypes: [PropulsionType], $includeReserved: Boolean = false, $includeDisabled: Boolean = false) {
+    vehicles(
+        range: $range,
+        propulsionTypes: $propulsionTypes,
+        operators: $operators,
+        codespaces: $codespaces,
+        includeReserved: $includeReserved,
+        lon: $lon,
+        lat: $lat,
+        count: $count,
+        formFactors: $formFactors,
+        includeDisabled: $includeDisabled
+    ) {
+        lat
+        lon
+        pricingPlan {
+            description
+            id
+            currency
+            isTaxable
+            name
+            price
+            surgePricing
+            url
+        }
+        system {
+            name
+            email
+            feedContactEmail
+            id
+            licenseUrl
+            language
+            phoneNumber
+            operator
+            purchaseUrl
+            startDate
+            shortName
+            timezone
+            url
+        }
+        isDisabled
+        isReserved
+        id
+        currentRangeMeters
+        rentalUris {
+            android
+            ios
+            web
+        }
+    }
+}
+`

--- a/src/mobility/getVehicles/query.ts
+++ b/src/mobility/getVehicles/query.ts
@@ -15,27 +15,52 @@ query ($lat: Float!, $lon: Float!, $range: Int!, $count: Int, $operators: [Strin
         lat
         lon
         pricingPlan {
-            description
+            description {
+                translation {
+                    language
+                    value
+                }
+            }
             id
             currency
             isTaxable
-            name
+            name {
+                translation {
+                    language
+                    value
+                }
+            }
             price
             surgePricing
             url
         }
         system {
-            name
+            name {
+                translation {
+                    language
+                    value
+                }
+            }
             email
             feedContactEmail
             id
             licenseUrl
             language
             phoneNumber
-            operator
+            operator {
+                translation {
+                    language
+                    value
+                }
+            }
             purchaseUrl
             startDate
-            shortName
+            shortName {
+                translation {
+                    language
+                    value
+                }
+            }
             timezone
             url
         }

--- a/src/mobility/index.ts
+++ b/src/mobility/index.ts
@@ -1,0 +1,1 @@
+export { default as createGetVehicles } from './getVehicles'

--- a/src/mobility/types.ts
+++ b/src/mobility/types.ts
@@ -1,3 +1,5 @@
+export type { GetVehiclesParams } from './getVehicles'
+
 export interface Translation {
     language: string
     value: string

--- a/src/mobility/types.ts
+++ b/src/mobility/types.ts
@@ -1,0 +1,88 @@
+export enum FormFactor {
+    BICYCLE = 'BICYCLE',
+    CAR = 'CAR',
+    MOPED = 'MOPED',
+    SCOOTER = 'SCOOTER',
+    OTHER = 'OTHER',
+}
+
+export enum PropulsionType {
+    HUMAN = 'HUMAN',
+    ELECTRIC_ASSIST = 'ELECTRIC_ASSIST',
+    ELECTRIC = 'ELECTRIC',
+    COMBUSTION = 'COMBUSTION',
+}
+
+export interface VehicleType {
+    id: string
+    formFactor: FormFactor
+    propulsionType: PropulsionType
+    maxRangeMeters?: number
+    name?: string
+}
+
+export interface PricingSegment {
+    start: number
+    rate: number
+    interval: number
+    end: number
+}
+
+export interface PricingPlan {
+    id: string
+    url: string
+    name: string
+    currency: string
+    price: number
+    isTaxable: boolean
+    description: string
+    perKmPricing: PricingSegment[]
+    perMinPricing: PricingSegment[]
+    surgePricing: boolean
+}
+
+export interface RentalUris {
+    android: string
+    ios: string
+    web: string
+}
+
+export interface RentalApp {
+    storeUri: string
+    discoveryUri: string
+}
+
+export interface RentalApps {
+    ios: RentalApp
+    android: RentalApp
+}
+
+export interface System {
+    id: string
+    language: string
+    name: string
+    shortName?: string
+    operator?: string
+    url?: string
+    purchaseUrl?: string
+    startDate?: string
+    phoneNumber?: string
+    email?: string
+    feedContactEmail?: string
+    timezone: string
+    licenseUrl?: string
+    rentalApps?: RentalApps
+}
+
+export interface Vehicle {
+    id: string
+    lat: number
+    lon: number
+    isReserved: boolean
+    isDisabled: boolean
+    currentRangeMeters: number
+    vehicleType: VehicleType
+    pricingPlan: PricingPlan
+    rentalUris: RentalUris
+    system: System
+}

--- a/src/mobility/types.ts
+++ b/src/mobility/types.ts
@@ -30,21 +30,21 @@ export interface PricingSegment {
 
 export interface PricingPlan {
     id: string
-    url: string
+    url?: string
     name: string
     currency: string
     price: number
     isTaxable: boolean
     description: string
-    perKmPricing: PricingSegment[]
-    perMinPricing: PricingSegment[]
-    surgePricing: boolean
+    perKmPricing?: PricingSegment[]
+    perMinPricing?: PricingSegment[]
+    surgePricing?: boolean
 }
 
 export interface RentalUris {
-    android: string
-    ios: string
-    web: string
+    android?: string
+    ios?: string
+    web?: string
 }
 
 export interface RentalApp {
@@ -53,8 +53,8 @@ export interface RentalApp {
 }
 
 export interface RentalApps {
-    ios: RentalApp
-    android: RentalApp
+    ios?: RentalApp
+    android?: RentalApp
 }
 
 export interface System {
@@ -82,7 +82,7 @@ export interface Vehicle {
     isDisabled: boolean
     currentRangeMeters: number
     vehicleType: VehicleType
-    pricingPlan: PricingPlan
-    rentalUris: RentalUris
+    pricingPlan?: PricingPlan
+    rentalUris?: RentalUris
     system: System
 }

--- a/src/mobility/types.ts
+++ b/src/mobility/types.ts
@@ -1,3 +1,12 @@
+export interface Translation {
+    language: string
+    value: string
+}
+
+export interface TranslatedString {
+    translation: Translation[]
+}
+
 export enum FormFactor {
     BICYCLE = 'BICYCLE',
     CAR = 'CAR',
@@ -31,11 +40,11 @@ export interface PricingSegment {
 export interface PricingPlan {
     id: string
     url?: string
-    name: string
+    name: TranslatedString
     currency: string
     price: number
     isTaxable: boolean
-    description: string
+    description: TranslatedString
     perKmPricing?: PricingSegment[]
     perMinPricing?: PricingSegment[]
     surgePricing?: boolean
@@ -60,9 +69,9 @@ export interface RentalApps {
 export interface System {
     id: string
     language: string
-    name: string
-    shortName?: string
-    operator?: string
+    name: TranslatedString
+    shortName?: TranslatedString
+    operator?: TranslatedString
     url?: string
     purchaseUrl?: string
     startDate?: string

--- a/src/service.ts
+++ b/src/service.ts
@@ -23,6 +23,8 @@ import {
     createGetQuaysForStopPlace,
 } from './stopPlace'
 
+import { createGetVehicles } from './mobility'
+
 import {
     createGetBikeRentalStation,
     createGetBikeRentalStations,
@@ -105,6 +107,7 @@ function createEnturService(config: ArgumentConfig) {
             config,
         ),
         getScootersByPosition: createGetScootersByPosition(config),
+        getVehicles: createGetVehicles(config),
     }
 }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -107,7 +107,9 @@ function createEnturService(config: ArgumentConfig) {
             config,
         ),
         getScootersByPosition: createGetScootersByPosition(config),
-        getVehicles: createGetVehicles(config),
+        mobility: {
+            getVehicles: createGetVehicles(config),
+        },
     }
 }
 


### PR DESCRIPTION
The Scooters API is deprecated and the new [Mobility v2 API](https://developer.entur.org/pages-mobility-docs-mobility-v2) will take over. This new API aggregates [GBFS](https://github.com/NABSA/gbfs) feeds from various operators and provides a GraphQL interface for this data.

This PR adds the `getVehicles` method that implements the `vehicles` query of the API. All fields are requested.

Check out the data and query [here](https://api.dev.entur.io/graphql-explorer/mobility?query=query%28%24lat%3AFloat%21%24lon%3AFloat%21%24range%3AInt%21%24count%3AInt%24operators%3A%5BString%5D%24codespaces%3A%5BString%5D%24formFactors%3A%5BFormFactor%5D%24propulsionTypes%3A%5BPropulsionType%5D%24includeReserved%3ABoolean%3Dfalse%24includeDisabled%3ABoolean%3Dfalse%29%7Bvehicles%28range%3A%24range%20propulsionTypes%3A%24propulsionTypes%20operators%3A%24operators%20codespaces%3A%24codespaces%20includeReserved%3A%24includeReserved%20lon%3A%24lon%20lat%3A%24lat%20count%3A%24count%20formFactors%3A%24formFactors%20includeDisabled%3A%24includeDisabled%29%7Blat%20lon%20pricingPlan%7Bdescription%7Btranslation%7Blanguage%20value%7D%7Did%20currency%20isTaxable%20name%7Btranslation%7Blanguage%20value%7D%7Dprice%20surgePricing%20url%7Dsystem%7Bname%7Btranslation%7Blanguage%20value%7D%7Demail%20feedContactEmail%20id%20licenseUrl%20language%20phoneNumber%20operator%7Bid%20name%7Btranslation%7Blanguage%20value%7D%7D%7DpurchaseUrl%20startDate%20shortName%7Btranslation%7Blanguage%20value%7D%7Dtimezone%20url%7DisDisabled%20isReserved%20id%20currentRangeMeters%20rentalUris%7Bandroid%20ios%20web%7D%7D%7D&variables=%7B%22lat%22%3A59.912%2C%22lon%22%3A10.75%2C%22range%22%3A500%7D).

The need for scoping is more obvious now to avoid name conflicts:
* We have exported all the mobility types under a single group `MobilityTypes`
* `getVehicles` is exposed under a `mobility` property on the service instance
```
import { MobilityTypes } from '@entur/sdk'

const vehicles: MobilityTypes.Vehicle[] = await service.mobility.getVehicles()
```

This prevents name conflicts with the existing `Operator` type, and future conflicts with the [Vehicle Positions API](https://developer.entur.org/pages-real-time-vehicle).