### PR TITLE
Deprecate 'lines' property on Situation

### DIFF
--- a/src/fields/Situation.ts
+++ b/src/fields/Situation.ts
@@ -25,7 +25,10 @@ export interface Situation {
     summary: MultilingualString[]
     description: MultilingualString[]
     advice: MultilingualString[]
-    lines: Line[]
+    /**
+     * @deprecated lines will be removed from Situation in a future major version.
+     */
+    lines?: Line[]
     validityPeriod: ValidityPeriod
     reportType: ReportType
     infoLinks: InfoLink[]


### PR DESCRIPTION
Listing all lines the a situation is set for can make the data returned incredible huge. Especially for JourneyPlanner v3 (OTP 2), which handles situations differently. 

We think that listing these lines under a given situation is not a common use case, and should not be part of the SDK, at least not for the current set of methods. If you need the full details on situations, you should call the JourneyPlanner GrahphQL API directly.

This PR does not remove the lines field on Situation. But its TypeScript type is set to optional to help TS users handle the undefined case. The field will be removed in a future major version.