### PR TITLE
Include LIFT in the default query modes for getTripPatterns

### DIFF
--- a/src/trip/index.ts
+++ b/src/trip/index.ts
@@ -110,6 +110,7 @@ const DEFAULT_MODES = [
     QueryMode.METRO,
     QueryMode.WATER,
     QueryMode.AIR,
+    QueryMode.LIFT,
 ]
 
 function getTripPatternsVariables(


### PR DESCRIPTION
Add `lift` to the default search modes so that lifts like Voss Gondolbane will appear in searches by default.