### PR TITLE
Remove types for deprecated boundary params for geocoder

### DIFF
--- a/src/geocoder/index.ts
+++ b/src/geocoder/index.ts
@@ -52,20 +52,6 @@ interface FocusApi {
 }
 
 export interface GetFeaturesParams {
-    /** @deprecated Use boundary object instead */
-    'boundary.rect.min_lon'?: number
-    /** @deprecated Use boundary object instead */
-    'boundary.rect.max_lon'?: number
-    /** @deprecated Use boundary object instead */
-    'boundary.rect.min_lat'?: number
-    /** @deprecated Use boundary object instead */
-    'boundary.rect.max_lat'?: number
-    /** @deprecated Use boundary object instead */
-    'boundary.country'?: string
-    /** @deprecated Use boundary object instead */
-    'boundary.county_ids'?: string
-    /** @deprecated Use boundary object instead */
-    'boundary.locality_ids'?: string
     boundary?: {
         rect?: {
             minLat: number


### PR DESCRIPTION
The old params will still work, but TypeScript will now complain if passed.