### PR TITLE
Rename EnturService to EnturClient and related parts

### DIFF
--- a/docs/advanced/queryJourneyPlanner.mdx
+++ b/docs/advanced/queryJourneyPlanner.mdx
@@ -38,10 +38,10 @@ An object containing a subset of `RequestInit` options that's applied to the req
 The example below finds lines that stops at the given stop places. Also check this out at [Shamash](https://api.staging.entur.io/journey-planner/v2/ide/?query=%7B%0A%20%20%0A%7D&variables=%7B%0A%20%20%22ids%22%3A%20%5B%22NSR%3AStopPlace%3A4089%22%2C%20%22NSR%3AStopPlace%3A1337%22%5D%0A%7D).
 
 ```typescript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
@@ -61,5 +61,7 @@ const variables = {
     ids: ['NSR:StopPlace:4089', 'NSR:StopPlace:1337'],
 }
 
-service.queryJourneyPlanner(query, variables).then((res) => console.log(res)) // Print out lines servicing these stop places
+enturClient
+    .queryJourneyPlanner(query, variables)
+    .then((res) => console.log(res)) // Print out lines servicing these stop places
 ```

--- a/docs/bikes/getBikeRentalStation.mdx
+++ b/docs/bikes/getBikeRentalStation.mdx
@@ -30,16 +30,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const bikeRentalStation = await service.getBikeRentalStation(
+        const bikeRentalStation = await enturClient.getBikeRentalStation(
             'YBE:VehicleSharingParkingArea:368',
         )
         console.log(bikeRentalStation)

--- a/docs/bikes/getBikeRentalStations.mdx
+++ b/docs/bikes/getBikeRentalStations.mdx
@@ -30,16 +30,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const bikeRentalStations = await service.getBikeRentalStations([
+        const bikeRentalStations = await enturClient.getBikeRentalStations([
             'YBE:VehicleSharingParkingArea:368',
             'YBE:VehicleSharingParkingArea:83',
         ])

--- a/docs/bikes/getBikeRentalStationsByPosition.mdx
+++ b/docs/bikes/getBikeRentalStationsByPosition.mdx
@@ -37,17 +37,17 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
         const bikeRentalStations =
-            await service.getBikeRentalStationsByPosition(
+            await enturClient.getBikeRentalStationsByPosition(
                 {
                     latitude: 59.95,
                     longitude: 10.75,

--- a/docs/geocoder/getFeatures.mdx
+++ b/docs/geocoder/getFeatures.mdx
@@ -23,7 +23,7 @@ The search string that should resemble the name of the desired stop place or add
 A set of coordinates to use when the weighting search results. Examples: `{ latitude: 59.909774, longitude: 10.763712 }`.
 
 The results closest to the coordinates will be weighted above results with equally good string matches.
-As an example, the street `Dronningens gate` exists both in Oslo and Trondheim. If you call `service.getFeatures('Dronningens gate', { latitude: 63.4305103, longitude: 10.3949874 })` (coordinates of Trondheim city center), the Dronningens gate in Trondheim will be preferred to the one in Oslo.
+As an example, the street `Dronningens gate` exists both in Oslo and Trondheim. If you call `enturClient.getFeatures('Dronningens gate', { latitude: 63.4305103, longitude: 10.3949874 })` (coordinates of Trondheim city center), the Dronningens gate in Trondheim will be preferred to the one in Oslo.
 
 ### params (`GetFeaturesQuery`) [Optional]
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -11,22 +11,24 @@ npm install @entur/sdk --save
 
 ## Setup
 
-Import the service creator:
+Import the client creator:
 
 ```javascript
-import createEnturService from '@entur/sdk'
+import createEnturClient from '@entur/sdk'
 ```
 
 Or if you are using CommonJS:
 
 ```javascript
-const createEnturService = require('@entur/sdk').default
+const createEnturClient = require('@entur/sdk').default
 ```
 
-Then create an instance of the service:
+Then create an instance of the client:
 
 ```javascript
-const service = createEnturService({ clientName: 'awesomecompany-awesomeapp' })
+const enturClient = createEnturClient({
+    clientName: 'awesomecompany-awesomeapp',
+})
 ```
 
 ### Configuration
@@ -44,7 +46,7 @@ followed by a hyphen and your application's name. See https://developer.entur.or
 
 #### hosts
 
-The Entur SDK uses multiple endpoints for its services. Each endpoint can be overridden with hosts config (in case you use a proxy or a local instance of the endpoint). Available hosts are:
+The Entur SDK uses multiple endpoints for its clients. Each endpoint can be overridden with hosts config (in case you use a proxy or a local instance of the endpoint). Available hosts are:
 
 ```javascript
 {
@@ -63,7 +65,7 @@ If you need to configure the fetch implementation that is used, use this. You co
 -   Do some common logging on all SDK requests
 
 ```
-const service = createEnturService({
+const enturClient = createEnturClient({
   clientName: 'awesomecompany-awesomeapp',
   fetch: (url, init) => {
     const startTime = new Date()

--- a/docs/mobility/getOperators.mdx
+++ b/docs/mobility/getOperators.mdx
@@ -26,16 +26,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const operators = await service.mobility.getOperators()
+        const operators = await enturClient.mobility.getOperators()
         console.log(operators)
     } catch (error) {
         console.error(error)

--- a/docs/mobility/getStations.mdx
+++ b/docs/mobility/getStations.mdx
@@ -40,16 +40,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const stations = await service.mobility.getStations({
+        const stations = await enturClient.mobility.getStations({
             lat: 59.95,
             lon: 10.75,
             range: 200,

--- a/docs/mobility/getVehicles.mdx
+++ b/docs/mobility/getVehicles.mdx
@@ -43,16 +43,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const vehicles = await service.mobility.getVehicles({
+        const vehicles = await enturClient.mobility.getVehicles({
             lat: 59.95,
             lon: 10.75,
             range: 200,

--- a/docs/nsr/getFareZone.mdx
+++ b/docs/nsr/getFareZone.mdx
@@ -24,16 +24,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const fareZone = await service.nsr.getFareZone('MOR:FareZone:411')
+        const fareZone = await enturClient.nsr.getFareZone('MOR:FareZone:411')
         console.log(fareZone)
     } catch (error) {
         console.error(error)

--- a/docs/nsr/getGroupOfStopPlaces.mdx
+++ b/docs/nsr/getGroupOfStopPlaces.mdx
@@ -24,16 +24,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const groupOfStopPlaces = await service.nsr.getGroupOfStopPlaces(
+        const groupOfStopPlaces = await enturClient.nsr.getGroupOfStopPlaces(
             'NSR:GroupOfStopPlaces:1',
         )
         console.log(groupOfStopPlaces)

--- a/docs/nsr/getParking.mdx
+++ b/docs/nsr/getParking.mdx
@@ -24,16 +24,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const parking = await service.nsr.getParking('NSR:Parking:41')
+        const parking = await enturClient.nsr.getParking('NSR:Parking:41')
         console.log(parking)
     } catch (error) {
         console.error(error)

--- a/docs/nsr/getParkingsForStopPlace.mdx
+++ b/docs/nsr/getParkingsForStopPlace.mdx
@@ -26,16 +26,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const parkings = await service.nsr.getParkingsForStopPlace(
+        const parkings = await enturClient.nsr.getParkingsForStopPlace(
             'NSR:StopPlace:337',
         )
         console.log(parkings)

--- a/docs/nsr/getQuay.mdx
+++ b/docs/nsr/getQuay.mdx
@@ -24,16 +24,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const quay = await service.nsr.getQuay('NSR:Quay:1')
+        const quay = await enturClient.nsr.getQuay('NSR:Quay:1')
         console.log(quay)
     } catch (error) {
         console.error(error)

--- a/docs/nsr/getStopPlace.mdx
+++ b/docs/nsr/getStopPlace.mdx
@@ -24,16 +24,18 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const stopPlace = await service.nsr.getStopPlace('NSR:StopPlace:337')
+        const stopPlace = await enturClient.nsr.getStopPlace(
+            'NSR:StopPlace:337',
+        )
         console.log(stopPlace)
     } catch (error) {
         console.error(error)

--- a/docs/nsr/getStopPlaceForQuay.mdx
+++ b/docs/nsr/getStopPlaceForQuay.mdx
@@ -24,16 +24,18 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const stopPlace = await service.nsr.getStopPlaceForQuay('NSR:Quay:1')
+        const stopPlace = await enturClient.nsr.getStopPlaceForQuay(
+            'NSR:Quay:1',
+        )
         console.log(stopPlace)
     } catch (error) {
         console.error(error)

--- a/docs/nsr/getTariffZone.mdx
+++ b/docs/nsr/getTariffZone.mdx
@@ -24,16 +24,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const tariffZone = await service.nsr.getTariffZone(
+        const tariffZone = await enturClient.nsr.getTariffZone(
             'NOR:TariffZone:4020',
         )
         console.log(tariffZone)

--- a/docs/nsr/getTopographicPlace.mdx
+++ b/docs/nsr/getTopographicPlace.mdx
@@ -24,16 +24,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const topographicPlace = await service.nsr.getTopographicPlace(
+        const topographicPlace = await enturClient.nsr.getTopographicPlace(
             'KVE:TopographicPlace:5402',
         )
         console.log(topographicPlace)

--- a/docs/places/getNearestPlaces.mdx
+++ b/docs/places/getNearestPlaces.mdx
@@ -41,16 +41,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```typescript
-import createEnturService, { TypeName } from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient, { TypeName } from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const nearbyPlaces = await service.getNearestPlaces(
+        const nearbyPlaces = await enturClient.getNearestPlaces(
             {
                 latitude: 59.911898,
                 longitude: 10.75038,

--- a/docs/scooters/getScootersByPosition.mdx
+++ b/docs/scooters/getScootersByPosition.mdx
@@ -38,16 +38,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     try {
-        const scooters = await service.getScootersByPosition({
+        const scooters = await enturClient.getScootersByPosition({
             latitude: 59.95,
             longitude: 10.75,
             distance: 200,
@@ -70,18 +70,18 @@ We have explicitly typed this by making the `Scooter` type a union type of `Batt
 The utility method `isBatteryScooter` and `isBatteryLevelScooter` can be used to refine the type, as shown in the example below:
 
 ```typescript
-import createEnturService, {
+import createEnturClient, {
     Scooter,
     isBatteryScooter,
     BatteryLevel,
 } from '@entur/sdk'
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function averageBatteryPercentage(): Promise<number> {
-    const scooters = await service.getScootersByPosition({
+    const scooters = await enturClient.getScootersByPosition({
         latitude: 59.909,
         longitude: 10.746,
         limit: 1,

--- a/docs/travel/findTrips.mdx
+++ b/docs/travel/findTrips.mdx
@@ -40,16 +40,16 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function findSomeTrips() {
     try {
-        const trips = await service.findTrips('Oslo S', 'Bergen stasjon')
+        const trips = await enturClient.findTrips('Oslo S', 'Bergen stasjon')
         console.log(trips)
     } catch (error) {
         console.error(error)

--- a/docs/travel/getTripPatterns.mdx
+++ b/docs/travel/getTripPatterns.mdx
@@ -58,7 +58,7 @@ interface InputWhiteListed {
 
 ### overrideConfig (`OverrideConfig`) [Optional]
 
-You can override the default service config on invocation if necessary.
+You can override the default client config on invocation if necessary.
 
 ```typescript
 interface OverrideConfig {
@@ -84,14 +84,14 @@ An object containing a subset of `RequestInit` options that's applied to the req
 ## Example
 
 ```javascript
-import createEnturService from '@entur/sdk'
-// or: const createEnturService = require('@entur/sdk').default
+import createEnturClient from '@entur/sdk'
+// or: const createEnturClient = require('@entur/sdk').default
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp'
 })
 
-service.getTripPatterns(
+enturClient.getTripPatterns(
     {
         from: {
             name: 'Ryllikvegen, Lillehammer',

--- a/docs/utils/convertFeatureToLocation.mdx
+++ b/docs/utils/convertFeatureToLocation.mdx
@@ -14,23 +14,23 @@ So what do you do? You use the handy `convertFeatureToLocation` utility.
 Example usage:
 
 ```javascript
-import createEnturService, { convertFeatureToLocation } from '@entur/sdk'
-// or: const { default: createEnturService, convertFeatureToLocation } = require('@entur/sdk')
+import createEnturClient, { convertFeatureToLocation } from '@entur/sdk'
+// or: const { default: createEnturClient, convertFeatureToLocation } = require('@entur/sdk')
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'awesomecompany-awesomeapp',
 })
 
 async function example() {
     const [osloFeatures, bergenFeatures] = await Promise.all([
-        service.getFeatures('Oslo S'),
-        service.getFeatures('Bergen stasjon'),
+        enturClient.getFeatures('Oslo S'),
+        enturClient.getFeatures('Bergen stasjon'),
     ])
 
     const osloLocation = convertFeatureToLocation(osloFeatures[0])
     const bergenLocation = convertFeatureToLocation(bergenFeatures[0])
 
-    const tripPatterns = await service.getTripPatterns({
+    const tripPatterns = await enturClient.getTripPatterns({
         from: osloLocation,
         to: bergenLocation,
     })

--- a/docs/utils/throttler.mdx
+++ b/docs/utils/throttler.mdx
@@ -12,19 +12,19 @@ To help you with this, we have a `throttler` utility that throttles the requests
 Example usage:
 
 ```javascript
-import createEnturService, {
+import createEnturClient, {
     throttler,
     convertFeatureToLocation,
 } from '@entur/sdk'
-// or: const { default: createEnturService, throttler, convertFeatureToLocation } = require('@entur/sdk')
+// or: const { default: createEnturClient, throttler, convertFeatureToLocation } = require('@entur/sdk')
 
-const service = createEnturService({
+const enturClient = createEnturClient({
     clientName: 'myawesomecompany-myawesomeapp',
 })
 
 async function getTripPatternsForVeryManyDifferentLocations() {
-    const [fromLocation] = await service.getFeatures('Oslo S')
-    const [toLocation] = await service.getFeatures('Drammen stasjon')
+    const [fromLocation] = await enturClient.getFeatures('Oslo S')
+    const [toLocation] = await enturClient.getFeatures('Drammen stasjon')
     const params = {
         searchDate: new Date(),
         from: convertFeatureToLocation(fromLocation),
@@ -37,7 +37,7 @@ async function getTripPatternsForVeryManyDifferentLocations() {
     // We pass the function and the huge list of arguments to the throttler.
     // The resulting list will be in the same order as the arguments passed.
     const tripPatterns = await throttler(
-        (query) => service.getTripPatterns(query),
+        (query) => enturClient.getTripPatterns(query),
         queries,
     )
     console.log('Done!')

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,7 @@ import { createGetFeatures, createGetFeaturesReverse } from './geocoder'
 
 import { ArgumentConfig, getServiceConfig } from './config'
 
-export interface EnturService {
+export interface EnturClient {
     queryJourneyPlanner: <T>(
         queryObj: string,
         variables: Record<string, unknown>,
@@ -88,7 +88,12 @@ export interface EnturService {
     nsr: NsrClient
 }
 
-function createEnturService(config: ArgumentConfig): EnturService {
+/**
+ * @deprecated Use `EnturClient` instead.
+ */
+export type EnturService = EnturClient
+
+function createEnturClient(config: ArgumentConfig): EnturClient {
     return {
         queryJourneyPlanner: <T>(
             queryObj: string,
@@ -136,4 +141,4 @@ function createEnturService(config: ArgumentConfig): EnturService {
     }
 }
 
-export default createEnturService
+export default createEnturClient

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,7 +64,7 @@ const HOST_CONFIG = {
 export function getServiceConfig(config: ArgumentConfig): ServiceConfig {
     if (!config || !config.clientName) {
         throw new Error(
-            'ERROR: You must pass a "clientName" to EnturService through the config argument. ' +
+            'ERROR: You must pass a "clientName" to EnturClient through the config argument. ' +
                 'See https://www.entur.org/dev/api/header/ for information.\n',
         )
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import 'regenerator-runtime/runtime'
 
-import createEnturService from './service'
-export type { EnturService } from './service'
+import createEnturClient from './client'
+export type { EnturClient, EnturService } from './client'
 
 export {
     convertFeatureToLocation,
@@ -44,7 +44,7 @@ export type { DeparturesById } from './departure'
 export { County } from './geocoder/countyIds'
 export type { GetFeaturesParams, GetFeaturesReverseParam } from './geocoder'
 
-export default createEnturService
+export default createEnturClient
 
 export type { Authority } from './fields/Authority'
 export type { BikeRentalStation } from './fields/BikeRentalStation'

--- a/test.js
+++ b/test.js
@@ -38,25 +38,25 @@ const JERNBANETORGET = 'NSR:StopPlace:58366'
 const OSLO_S = 'NSR:StopPlace:59872'
 const MISSING = 'NSR:StopPlace:5483957348574389'
 
-const { default: createEnturService } = require('./src')
+const { default: createEnturClient } = require('./src')
 
-const service = createEnturService({
+const client = createEnturClient({
     clientName: 'SDK cli-test',
 })
 
 function getMethodToRun(name) {
     switch (name) {
         case 'getTripPatterns':
-            return service.getTripPatterns(
+            return client.getTripPatterns(
                 MOMOEN_LOCATION,
                 LILLESTROM_LEGESENTER_LOCATION,
                 undefined,
                 [],
             )
         case 'getStopPlace':
-            return service.getStopPlace(JERNBANETORGET)
+            return client.getStopPlace(JERNBANETORGET)
         case 'getStopPlaces':
-            return service.getStopPlaces([
+            return client.getStopPlaces([
                 OSLO_S,
                 MISSING,
                 JERNBANETORGET,
@@ -64,13 +64,13 @@ function getMethodToRun(name) {
                 LILLEHAMMER_STASJON,
             ])
         case 'getStopPlaceFacilities':
-            return service.getStopPlaceFacilities(JERNBANETORGET)
+            return client.getStopPlaceFacilities(JERNBANETORGET)
         case 'getQuaysFromStopPlace':
-            return service.getQuaysFromStopPlace(JERNBANETORGET)
+            return client.getQuaysFromStopPlace(JERNBANETORGET)
         case 'getBikeRentalStation':
-            return service.getBikeRentalStation(JERNBANETORGET_BIKE_STOP)
+            return client.getBikeRentalStation(JERNBANETORGET_BIKE_STOP)
         case 'getBikeRentalStationsByPosition':
-            return service.getBikeRentalStationsByPosition(
+            return client.getBikeRentalStationsByPosition(
                 {
                     latitude: 59.911898,
                     longitude: 10.75038,
@@ -78,14 +78,14 @@ function getMethodToRun(name) {
                 50,
             )
         case 'getDeparturesFromStopPlace':
-            return service.getDeparturesFromStopPlace(JERNBANETORGET)
+            return client.getDeparturesFromStopPlace(JERNBANETORGET)
         case 'getDeparturesFromStopPlaces':
-            return service.getDeparturesFromStopPlaces(
+            return client.getDeparturesFromStopPlaces(
                 [JERNBANETORGET, HAMAR_STASJON, LILLEHAMMER_STASJON],
                 { limit: 2 },
             )
         case 'getDeparturesBetweenStopPlaces':
-            return service.getDeparturesBetweenStopPlaces(
+            return client.getDeparturesBetweenStopPlaces(
                 LILLEHAMMER_STASJON,
                 HAMAR_STASJON,
             )


### PR DESCRIPTION
The SDK is a _client library_, used to consume Entur's services. It is not a service itself. Therefore it is weird to call it a service. "Client" is a more commonly used word for this.

Examples of other SDKs using the client term:
* Auth0 (https://github.com/auth0/node-auth0)
* AWS (https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/getting-started-nodejs.html)

Renaming `createEnturService` is not a breaking change, since it is a default export. But renaming the interface `EnturService` can be considered a breaking change. I therefore added an alias, which is deprecated and tells the user to use `EnturClient` instead.