### PR TITLE
Add options param in signatures where it was missing in docs

### DIFF
--- a/docs/bikes/getBikeRentalStation.mdx
+++ b/docs/bikes/getBikeRentalStation.mdx
@@ -7,7 +7,7 @@ route: /bikes/getBikeRentalStation
 # getBikeRentalStation
 
 ```typescript
-(stationId: string) => Promise<BikeRentalStation>
+(stationId: string, options?: RequestOptions) => Promise<BikeRentalStation>
 ```
 
 `getBikeRentalStation` finds a single bike rental station by its ID.

--- a/docs/bikes/getBikeRentalStations.mdx
+++ b/docs/bikes/getBikeRentalStations.mdx
@@ -7,7 +7,7 @@ route: /bikes/getBikeRentalStations
 # getBikeRentalStations
 
 ```typescript
-(stationIds: Array<string>) => Promise<Array<BikeRentalStation>>
+(stationIds: Array<string>, options?: RequestOptions) => Promise<Array<BikeRentalStation>>
 ```
 
 `getBikeRentalStations` finds multiple bike rental stations according to an array of IDs. The returned array will have the same length and order as the input array, and may contain undefined values if the corresponding ID didn't produce a result.

--- a/docs/bikes/getBikeRentalStationsByPosition.mdx
+++ b/docs/bikes/getBikeRentalStationsByPosition.mdx
@@ -7,7 +7,7 @@ route: /bikes/getBikeRentalStationsByPosition
 # getBikeRentalStationsByPosition
 
 ```typescript
-(coordinates: Coordinates, distance?: number) => Promise<Array<BikeRentalStation>>
+(coordinates: Coordinates, distance?: number, options?: RequestOptions) => Promise<Array<BikeRentalStation>>
 ```
 
 `getBikeRentalStations` finds bike rental stations within an area surrounding a coordinate.

--- a/docs/departures/getDeparturesBetweenStopPlaces.mdx
+++ b/docs/departures/getDeparturesBetweenStopPlaces.mdx
@@ -7,7 +7,7 @@ route: /departures/getDeparturesBetweenStopPlaces
 # getDeparturesBetweenStopPlaces
 
 ```typescript
-(fromStopPlaceId: string, toStopPlaceId: string, params?: GetDeparturesBetweenStopPlacesParams) => Promise<Array<Departure>>
+(fromStopPlaceId: string, toStopPlaceId: string, params?: GetDeparturesBetweenStopPlacesParams, options?: RequestOptions) => Promise<Array<Departure>>
 ```
 
 `getDeparturesBetweenStopPlaces` finds departures from a stop place, but only departures that will go to the destination stop place.

--- a/docs/departures/getDeparturesForServiceJourney.mdx
+++ b/docs/departures/getDeparturesForServiceJourney.mdx
@@ -7,7 +7,7 @@ route: /departures/getDeparturesForServiceJourney
 # getDeparturesForServiceJourney
 
 ```typescript
-(id: string, date?: string) => Promise<Array<Departure>>
+(id: string, date?: string, options?: RequestOptions) => Promise<Array<Departure>>
 ```
 
 `getDeparturesForServiceJourney` finds departures for a given service journey ID. You can also provide a desired date on the form "YYYY-MM-DD".

--- a/docs/departures/getDeparturesFromQuays.mdx
+++ b/docs/departures/getDeparturesFromQuays.mdx
@@ -7,7 +7,7 @@ route: /departures/getDeparturesFromQuays
 # getDeparturesFromQuays
 
 ```typescript
-(quayIds: Array<string>, params?: GetDeparturesParams) => Promise<Array<{ id: string, departures: Departure[] } | undefined>>
+(quayIds: Array<string>, params?: GetDeparturesParams, options?: RequestOptions) => Promise<Array<{ id: string, departures: Departure[] } | undefined>>
 ```
 
 `getDeparturesFromQuays` finds departures from one or more given quays.

--- a/docs/departures/getDeparturesFromStopPlace.mdx
+++ b/docs/departures/getDeparturesFromStopPlace.mdx
@@ -7,7 +7,7 @@ route: /departures/getDeparturesFromStopPlace
 # getDeparturesFromStopPlace
 
 ```typescript
-(stopPlaceId: string, params?: GetDeparturesParams) => Promise<Array<Departure>>
+(stopPlaceId: string, params?: GetDeparturesParams, options?: RequestOptions) => Promise<Array<Departure>>
 ```
 
 `getDeparturesFromStopPlace` finds departures from one given stop place. Also see `getDeparturesFromStopPlaces` for fetching for multiple stops simultaneously.

--- a/docs/departures/getDeparturesFromStopPlaces.mdx
+++ b/docs/departures/getDeparturesFromStopPlaces.mdx
@@ -7,7 +7,7 @@ route: /departures/getDeparturesFromStopPlaces
 # getDeparturesFromStopPlaces
 
 ```typescript
-(stopPlaceIds: Array<string>, params?: GetDeparturesParams) => Promise<Array<{ id: string, departures: Departure[] } | undefined>>
+(stopPlaceIds: Array<string>, params?: GetDeparturesParams, options?: RequestOptions) => Promise<Array<{ id: string, departures: Departure[] } | undefined>>
 ```
 
 `getDeparturesFromStopPlaces` finds departures from one or more given stop places. Also see `getDeparturesFromStopPlace` for a simpler interface for fetching departures for a single stop.

--- a/docs/geocoder/getFeatures.mdx
+++ b/docs/geocoder/getFeatures.mdx
@@ -7,7 +7,7 @@ route: /geocoder/getFeatures
 # getFeatures
 
 ```typescript
-(query: string, coords?: Coordinates, params?: GetFeaturesQuery) => Promise<Array<Feature>>
+(query: string, coords?: Coordinates, params?: GetFeaturesQuery, options?: RequestOptions) => Promise<Array<Feature>>
 ```
 
 `getFeatures` is for searching for stop places, stations or addresses.

--- a/docs/geocoder/getFeaturesReverse.mdx
+++ b/docs/geocoder/getFeaturesReverse.mdx
@@ -7,7 +7,7 @@ route: /geocoder/getFeaturesReverse
 # getFeaturesReverse
 
 ```typescript
-(coords: Coordinates, params?: GetFeaturesReverseParam) => Promise<Array<Feature>>
+(coords: Coordinates, params?: GetFeaturesReverseParam, options?: RequestOptions) => Promise<Array<Feature>>
 ```
 
 `getFeaturesReverse` does a reverse lookup of stop places, stations or addresses around the given coordinates.

--- a/docs/places/getNearestPlaces.mdx
+++ b/docs/places/getNearestPlaces.mdx
@@ -7,7 +7,7 @@ route: /places/getNearestPlaces
 # getNearestPlaces
 
 ```typescript
-(coordinates: { latitude: number, longitude: number }, params?: NearestPlacesParams) => Promise<Array<NearestPlace>>
+(coordinates: { latitude: number, longitude: number }, params?: NearestPlacesParams, options?: RequestOptions) => Promise<Array<NearestPlace>>
 ```
 
 Finds the nearest places to a given coordinate.

--- a/docs/places/getParentStopPlace.mdx
+++ b/docs/places/getParentStopPlace.mdx
@@ -7,7 +7,7 @@ route: /places/getParentStopPlace
 # getParentStopPlace
 
 ```typescript
-(id: string, params?: StopPlaceParams) => Promise<StopPlaceDetails>>
+(id: string, params?: StopPlaceParams, options?: RequestOptions) => Promise<StopPlaceDetails>>
 ```
 
 ## Parameters

--- a/docs/places/getQuaysForStopPlace.mdx
+++ b/docs/places/getQuaysForStopPlace.mdx
@@ -7,7 +7,7 @@ route: /places/getQuaysForStopPlace
 # getQuaysForStopPlace
 
 ```typescript
-(stopPlaceId: string, params?: StopPlaceParams) => Promise<Array<Quay>>
+(stopPlaceId: string, params?: StopPlaceParams, options?: RequestOptions) => Promise<Array<Quay>>
 ```
 
 Returns all the quays that belong to a stop place.

--- a/docs/places/getStopPlace.mdx
+++ b/docs/places/getStopPlace.mdx
@@ -7,7 +7,7 @@ route: /places/getStopPlace
 # getStopPlace
 
 ```typescript
-(id: string, params?: StopPlaceParams) => Promise<StopPlaceDetails>
+(id: string, params?: StopPlaceParams, options?: RequestOptions) => Promise<StopPlaceDetails>
 ```
 
 `getStopPlace` finds the stop place with the given ID.

--- a/docs/places/getStopPlaceFacilities.mdx
+++ b/docs/places/getStopPlaceFacilities.mdx
@@ -7,7 +7,7 @@ route: /places/getStopPlaceFacilities
 # getStopPlaceFacilities DEPRECATED
 
 ```typescript
-(stopPlaceId: string) => Promise<StopPlaceFacilities>
+(stopPlaceId: string, options?: RequestOptions) => Promise<StopPlaceFacilities>
 ```
 
 This method is deprecated. Please use one or both of these NSR methods instead:

--- a/docs/places/getStopPlaces.mdx
+++ b/docs/places/getStopPlaces.mdx
@@ -7,7 +7,7 @@ route: /places/getStopPlaces
 # getStopPlaces
 
 ```typescript
-(ids: Array<string>, params?: StopPlaceParams) => Promise<Array<StopPlaceDetails | undefined>>
+(ids: Array<string>, params?: StopPlaceParams, options?: RequestOptions) => Promise<Array<StopPlaceDetails | undefined>>
 ```
 
 `getStopPlaces` finds multiple stop places according to an array of IDs. The returned array will have the same order as the input array, and may contain undefined values if the corresponding ID didn't produce a result.

--- a/docs/places/getStopPlacesByPosition.mdx
+++ b/docs/places/getStopPlacesByPosition.mdx
@@ -7,7 +7,7 @@ route: /places/getStopPlacesByPosition
 # getStopPlacesByPosition
 
 ```typescript
-(coordinates: Coordinates, distance?: number, params?: StopPlaceParams) => Promise<Array<StopPlaceDetails>>
+(coordinates: Coordinates, distance?: number, params?: StopPlaceParams, options?: RequestOptions) => Promise<Array<StopPlaceDetails>>
 ```
 
 `getStopPlacesByPosition` finds stop places within an area surrounding a coordinate.

--- a/docs/scooters/getScootersByPosition.mdx
+++ b/docs/scooters/getScootersByPosition.mdx
@@ -7,7 +7,7 @@ route: /scooters/getScootersByPosition
 # getScootersByPosition
 
 ```typescript
-(params: GetScootersByPositionParams) => Promise<Scooter[]>
+(params: GetScootersByPositionParams, options?: RequestOptions) => Promise<Scooter[]>
 ```
 
 `getScooters` finds scooters within an area surrounding a coordinate.

--- a/docs/travel/findTrips.mdx
+++ b/docs/travel/findTrips.mdx
@@ -7,7 +7,7 @@ route: /travel/findTrips
 # findTrips
 
 ```typescript
-(from: string, to: string, date?: Date | string | number) => Promise<Array<TripPattern>>
+(from: string, to: string, date?: Date | string | number, options?: RequestOptions) => Promise<Array<TripPattern>>
 ```
 
 Finds up to 5 trip patterns from `from` to `to` at the time specified. This is a convenience method, which first tries to find locations for the given `from` and `to` strings before searching for trips between them. If you need more control, see the [`getTripPatterns`](/travel/getTripPatterns) method.

--- a/docs/travel/getTripPatterns.mdx
+++ b/docs/travel/getTripPatterns.mdx
@@ -7,7 +7,7 @@ route: /travel/getTripPatterns
 # getTripPatterns
 
 ```typescript
-(params: GetTripPatternsParams, overrideConfig?: OverrideConfig) => Promise<Array<TripPattern>>
+(params: GetTripPatternsParams, overrideConfig?: OverrideConfig, options?: RequestOptions) => Promise<Array<TripPattern>>
 ```
 
 `getTripPatterns` is for searching for itineraries for a trip from some location to a destination at a given time. The method takes one argument `query`, which is an object with search parameters.


### PR DESCRIPTION
Not all documentation articles had their method signatures updated with the request options parameter.