### PR TITLE
Added new function mobility.getStationsById()

### DIFF
--- a/docs/bikes/getBikeRentalStations.mdx
+++ b/docs/bikes/getBikeRentalStations.mdx
@@ -43,7 +43,7 @@ async function example() {
             'YBE:VehicleSharingParkingArea:368',
             'YBE:VehicleSharingParkingArea:83',
         ])
-        console.log(bikeRentalStation)
+        console.log(bikeRentalStations)
     } catch (error) {
         console.error(error)
     }

--- a/docs/bikes/getBikeRentalStations.mdx
+++ b/docs/bikes/getBikeRentalStations.mdx
@@ -41,7 +41,7 @@ async function example() {
     try {
         const bikeRentalStations = await enturClient.getBikeRentalStations([
             'YBE:VehicleSharingParkingArea:368',
-            'YBE:VehicleSharingParkingArea:83',
+            'YOS:VehicleSharingParkingArea:495',
         ])
         console.log(bikeRentalStations)
     } catch (error) {

--- a/src/mobility/getStationsById/index.ts
+++ b/src/mobility/getStationsById/index.ts
@@ -1,0 +1,30 @@
+import { RequestOptions } from '../../http'
+import { getServiceConfig, ArgumentConfig } from '../../config'
+import { mobilityQuery } from '../../api'
+
+import { Station } from '../types'
+
+import getStationsQuery from './query'
+
+export interface GetStationsByIdParams {
+    /** Return only stations with the given IDs. */
+    stationIds: string[]
+}
+
+export default function createGetStationsById(argConfig: ArgumentConfig) {
+    const config = getServiceConfig(argConfig)
+
+    return async function getStationsById(
+        params: GetStationsByIdParams,
+        options?: RequestOptions,
+    ): Promise<Station[]> {
+        const data = await mobilityQuery<{ stationsById: Station[] }>(
+            getStationsQuery,
+            params,
+            config,
+            options,
+        )
+
+        return data?.stationsById || []
+    }
+}

--- a/src/mobility/getStationsById/query.ts
+++ b/src/mobility/getStationsById/query.ts
@@ -1,0 +1,105 @@
+export default `
+query ($stationIds: [String]!) {
+    stationsById(
+      ids: $stationIds
+    ) {
+        id
+        name {
+            translation {
+                language
+                value
+            }
+        }
+        lat
+        lon
+        address
+        capacity
+        rentalUris {
+                android
+                ios
+                web
+        }
+        numBikesAvailable
+        numDocksAvailable
+        isInstalled
+        isRenting
+        isReturning
+        lastReported
+        system {
+                id
+                language
+                name {
+                    translation {
+                        language
+                        value
+                    }
+                }
+                shortName {
+                    translation {
+                        language
+                        value
+                    }
+                }
+                operator {
+                    id
+                    name {
+                        translation {
+                        language
+                        value
+                        }
+                    }
+                }
+                url
+                purchaseUrl
+                startDate
+                phoneNumber
+                email
+                feedContactEmail
+                timezone
+                licenseUrl
+                rentalApps {
+                    ios {
+                        storeUri
+                        discoveryUri
+                    }
+                    android {
+                        storeUri
+                        discoveryUri
+                    }
+                }
+        }
+        pricingPlans {
+            id
+            url
+            name {
+                translation {
+                    language
+                    value
+                }
+            }
+            currency
+            price
+            isTaxable
+            description {
+                translation {
+                    language
+                    value
+                }
+            }
+            perKmPricing {
+                start
+                rate
+                interval
+                end
+            }
+            perMinPricing {
+                start
+                rate
+                interval
+                end
+            }
+            surgePricing
+        }
+    }
+}
+`

--- a/src/mobility/index.ts
+++ b/src/mobility/index.ts
@@ -1,12 +1,14 @@
 import { ArgumentConfig } from '../config'
 
 import { default as createGetStations } from './getStations'
+import { default as createGetStationsById } from './getStationsById'
 import { default as createGetVehicles } from './getVehicles'
 import { default as createGetOperators } from './getOperators'
 
 export interface MobilityClient {
     getOperators: ReturnType<typeof createGetOperators>
     getStations: ReturnType<typeof createGetStations>
+    getStationsById: ReturnType<typeof createGetStationsById>
     getVehicles: ReturnType<typeof createGetVehicles>
 }
 
@@ -14,6 +16,7 @@ export default function createClient(config: ArgumentConfig): MobilityClient {
     return {
         getOperators: createGetOperators(config),
         getStations: createGetStations(config),
+        getStationsById: createGetStationsById(config),
         getVehicles: createGetVehicles(config),
     }
 }


### PR DESCRIPTION
Added new function mobility.getStationsById() + minor fixes in code examples in the docs.

## `getStationsById()`
* This function fetches the same data as getStations() but through mobility-APIs stationsById.
* The only (mandatory) argument is stationIDs; an array of strings.
* Why? Because getStations() is based on finding stations in a geographical area, and does not offer fetching stations purely from station-IDs.

<img width="500" alt="Screenshot 2021-09-10 at 14 32 32" src="https://user-images.githubusercontent.com/32192420/132857217-879e9990-cc97-4d24-88a2-0f14095e0f0e.png">

## Docs // code example
* Fixed typo
* One station ID did not return any data, replaced with one that does.