### PR TITLE
Uninstall eslint-plugin-prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,12 +4,11 @@ module.exports = {
     env: {
         node: true,
     },
-    plugins: ['@typescript-eslint', 'prettier', 'eslint-plugin-tsdoc'],
+    plugins: ['@typescript-eslint', 'eslint-plugin-tsdoc'],
     extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
     rules: {
         '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
         '@typescript-eslint/member-delimiter-style': 'off',
-        'prettier/prettier': 'error',
         'tsdoc/syntax': 'error',
     },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
                 "docz": "^2.3.1",
                 "eslint": "^8.6.0",
                 "eslint-plugin-import": "^2.23.2",
-                "eslint-plugin-prettier": "^4.0.0",
                 "eslint-plugin-tsdoc": "^0.2.14",
                 "firebase-tools": "^9.14.0",
                 "gatsby-theme-docz": "^2.3.1",
@@ -12899,27 +12898,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/eslint-plugin-prettier": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-            "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-            "dev": true,
-            "dependencies": {
-                "prettier-linter-helpers": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            },
-            "peerDependencies": {
-                "eslint": ">=7.28.0",
-                "prettier": ">=2.0.0"
-            },
-            "peerDependenciesMeta": {
-                "eslint-config-prettier": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/eslint-plugin-react": {
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
@@ -13931,12 +13909,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
             "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-            "dev": true
-        },
-        "node_modules/fast-diff": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
         "node_modules/fast-glob": {
@@ -28029,18 +28001,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-            "dev": true,
-            "dependencies": {
-                "fast-diff": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/pretty-bytes": {
@@ -48629,15 +48589,6 @@
                 }
             }
         },
-        "eslint-plugin-prettier": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-            "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
-            "dev": true,
-            "requires": {
-                "prettier-linter-helpers": "^1.0.0"
-            }
-        },
         "eslint-plugin-react": {
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.28.0.tgz",
@@ -49270,12 +49221,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
             "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-            "dev": true
-        },
-        "fast-diff": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
         "fast-glob": {
@@ -60469,15 +60414,6 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
             "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
             "dev": true
-        },
-        "prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-            "dev": true,
-            "requires": {
-                "fast-diff": "^1.1.2"
-            }
         },
         "pretty-bytes": {
             "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "docz": "^2.3.1",
         "eslint": "^8.6.0",
         "eslint-plugin-import": "^2.23.2",
-        "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-tsdoc": "^0.2.14",
         "firebase-tools": "^9.14.0",
         "gatsby-theme-docz": "^2.3.1",


### PR DESCRIPTION
Prettier is run independently of ESLint in the npm lint script, so it is unnecessary to use the ESLint plugin as well.