### PR TITLE
Deprecate old geocoder methods and related types

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,9 @@ export interface EnturClient {
         variables: Record<string, unknown>,
         options?: RequestOptions,
     ) => Promise<T>
+    /** @deprecated Use geocoder.autocomplete instead. */
     getFeatures: ReturnType<typeof createGetFeatures>
+    /** @deprecated Use geocoder.reverse instead. */
     getFeaturesReverse: ReturnType<typeof createGetFeaturesReverse>
     getTripPatterns: ReturnType<typeof createGetTripPatterns>
     findTrips: ReturnType<typeof createFindTrips>

--- a/src/constants/featureCategory.ts
+++ b/src/constants/featureCategory.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated The Feature type is deprecated, use the geocoder.autocomplete and geocoder.reverse methods instead and related types.
+ */
 export enum FeatureCategory {
     ONSTREET_BUS = 'onstreetBus',
     ONSTREET_TRAM = 'onstreetTram',

--- a/src/types/Feature.ts
+++ b/src/types/Feature.ts
@@ -1,5 +1,8 @@
 import { FeatureCategory } from '../constants/featureCategory'
 
+/**
+ * @deprecated Use the geocoder.autocomplete and geocoder.reverse methods instead and related types.
+ */
 export type Feature = {
     geometry: {
         coordinates: [number, number] // longitude, latitude


### PR DESCRIPTION
You should use [`geocoder.autocomplete`](https://sdk.entur.org/geocoder/autocomplete) and [`geocoder.reverse`](https://sdk.entur.org/geocoder/reverse) instead.