### PR TITLE
Deprecate all OTP 1 / JP v2 related queries and types

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -53,30 +53,149 @@ export interface EnturClient {
     getFeatures: ReturnType<typeof createGetFeatures>
     /** @deprecated Use geocoder.reverse instead. */
     getFeaturesReverse: ReturnType<typeof createGetFeaturesReverse>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getTripPatterns: ReturnType<typeof createGetTripPatterns>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     findTrips: ReturnType<typeof createFindTrips>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getStopPlaceDepartures: typeof getStopPlaceDeparturesDEPRECATED
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getDeparturesFromStopPlace: ReturnType<
         typeof createGetDeparturesFromStopPlace
     >
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getDeparturesFromStopPlaces: ReturnType<
         typeof createGetDeparturesFromStopPlaces
     >
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getDeparturesFromQuays: ReturnType<typeof createGetDeparturesFromQuays>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getDeparturesBetweenStopPlaces: ReturnType<
         typeof createGetDeparturesBetweenStopPlaces
     >
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getDeparturesForServiceJourney: ReturnType<
         typeof createGetDeparturesForServiceJourney
     >
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getNearestPlaces: ReturnType<typeof createGetNearestPlaces>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getStopPlace: ReturnType<typeof createGetStopPlace>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getStopPlaces: ReturnType<typeof createGetStopPlaces>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getParentStopPlace: ReturnType<typeof createGetParentStopPlace>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getStopPlacesByPosition: ReturnType<typeof createGetStopPlacesByPosition>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getQuaysForStopPlace: ReturnType<typeof createGetQuaysForStopPlace>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getBikeRentalStation: ReturnType<typeof createGetBikeRentalStation>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getBikeRentalStations: ReturnType<typeof createGetBikeRentalStations>
+
+    /**
+     * @deprecated
+     * The JourneyPlanner v2 queries and types are deprecated.
+     * Write your own GraphQL queries for JourneyPlanner v3.
+     * Write your own types or use those from JourneyPlannerTypes where applicable.
+     */
     getBikeRentalStationsByPosition: ReturnType<
         typeof createGetBikeRentalStationsByPosition
     >

--- a/src/fields/Authority.ts
+++ b/src/fields/Authority.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Authority {
     codeSpace: string // Added by mapper
     id: string

--- a/src/fields/BikeRentalStation.ts
+++ b/src/fields/BikeRentalStation.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface BikeRentalStation {
     id: string
     name: string

--- a/src/fields/BookingArrangement.ts
+++ b/src/fields/BookingArrangement.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export enum BookingMethod {
     CALL_DRIVER = 'callDriver',
     CALL_OFFICE = 'callOffice',
@@ -8,6 +14,12 @@ export enum BookingMethod {
     NONE = 'none',
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export enum BookWhen {
     ADVANCE_ONLY = 'advanceOnly',
     UNTIL_PREVIOUS_DAY = 'untilPreviousDay',
@@ -18,6 +30,12 @@ export enum BookWhen {
     OTHER = 'other',
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export enum BuyWhen {
     ON_RESERVATION = 'onReservation',
     IN_ADVANCE = 'inAdvance',
@@ -33,6 +51,12 @@ export enum BuyWhen {
     OTHER = 'other',
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export enum BookingAccess {
     PUBLIC_ACCESS = 'publicAccess',
     AUTHORISED_PUBLIC = 'authorisedPublic',
@@ -40,6 +64,12 @@ export enum BookingAccess {
     OTHER = 'other',
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface BookingContact {
     contactPerson?: string
     email?: string
@@ -48,6 +78,12 @@ export interface BookingContact {
     url?: string
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface BookingArrangement {
     bookingAccess?: BookingAccess
     bookingContact?: BookingContact

--- a/src/fields/Departure.ts
+++ b/src/fields/Departure.ts
@@ -24,6 +24,12 @@ import {
     Situation,
 } from './Situation'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Departure {
     actualArrivalTime?: string // Only available AFTER arrival has taken place
     actualDepartureTime?: string // Only available AFTER departure has taken place

--- a/src/fields/EstimatedCall.ts
+++ b/src/fields/EstimatedCall.ts
@@ -24,6 +24,12 @@ import {
     BookingArrangement,
 } from './BookingArrangement'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface EstimatedCall {
     actualArrivalTime?: string // Only available AFTER arrival has taken place
     actualDepartureTime?: string // Only available AFTER departure has taken place

--- a/src/fields/Interchange.ts
+++ b/src/fields/Interchange.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Interchange {
     guaranteed: boolean
     staySeated: boolean

--- a/src/fields/Leg.ts
+++ b/src/fields/Leg.ts
@@ -65,6 +65,12 @@ import {
 
 import { Notice } from './Notice'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Leg {
     /** The aimed date and time this leg ends. */
     aimedEndTime: string

--- a/src/fields/Line.ts
+++ b/src/fields/Line.ts
@@ -26,6 +26,12 @@ type FlexibleLineType =
     | 'fixed'
     | 'other'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type Line = {
     /** @deprecated Use bookingArrangements on Leg or ServiceJourney instead. */
     bookingArrangements?: BookingArrangement

--- a/src/fields/Notice.ts
+++ b/src/fields/Notice.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Notice {
     text: string
 }

--- a/src/fields/Operator.ts
+++ b/src/fields/Operator.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Operator {
     id: string
     name: string

--- a/src/fields/Place.ts
+++ b/src/fields/Place.ts
@@ -12,6 +12,12 @@ import {
     BikeRentalStation,
 } from './BikeRentalStation'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Place {
     latitude: number
     longitude: number

--- a/src/fields/PointsOnLink.ts
+++ b/src/fields/PointsOnLink.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type PointsOnLink = {
     points: string
     length: number

--- a/src/fields/Quay.ts
+++ b/src/fields/Quay.ts
@@ -12,6 +12,12 @@ import {
     StopPlace,
 } from './StopPlace'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Quay {
     id: string
     name: string

--- a/src/fields/ServiceJourney.ts
+++ b/src/fields/ServiceJourney.ts
@@ -25,6 +25,12 @@ interface JourneyPattern {
     notices?: Notice[]
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface ServiceJourney {
     id: string
     bookingArrangements?: BookingArrangement

--- a/src/fields/Situation.ts
+++ b/src/fields/Situation.ts
@@ -8,18 +8,42 @@ import {
     Line,
 } from './Line'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type ReportType = 'general' | 'incident' | null
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface ValidityPeriod {
     startTime: string
     endTime: string
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface InfoLink {
     uri: string
     label: string
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Situation {
     situationNumber: string
     summary: MultilingualString[]

--- a/src/fields/StopPlace.ts
+++ b/src/fields/StopPlace.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface StopPlace {
     id: string
     description?: string

--- a/src/trip/index.ts
+++ b/src/trip/index.ts
@@ -21,6 +21,12 @@ import {
     OverrideConfig,
 } from '../config'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface TripPattern {
     /** Total distance for the trip, in meters. */
     distance: number
@@ -46,11 +52,23 @@ export interface TripPattern {
     walkDistance: number
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface TransportSubmodeParam {
     transportMode: TransportMode
     transportSubmodes: TransportSubmode[]
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface InputBanned {
     lines?: string[]
     authorities?: string[]
@@ -60,12 +78,24 @@ export interface InputBanned {
     serviceJourneys?: string[]
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface InputWhiteListed {
     lines?: string[]
     authorities?: string[]
     organisations?: string[]
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface GetTripPatternsParams {
     from: Location
     to: Location
@@ -84,6 +114,12 @@ export interface GetTripPatternsParams {
     whiteListed?: InputWhiteListed
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 interface GetTripPatternsVariables {
     from: Location
     to: Location

--- a/src/types/DestinationDisplay.ts
+++ b/src/types/DestinationDisplay.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface DestinationDisplay {
     frontText: string
 }

--- a/src/types/FlexibleLineType.ts
+++ b/src/types/FlexibleLineType.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type FlexibleLineType =
     | 'corridorService'
     | 'mainRouteWithFlexibleEnds'

--- a/src/types/Location.ts
+++ b/src/types/Location.ts
@@ -1,5 +1,11 @@
 import { Coordinates } from './Coordinates'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface Location {
     name?: string
     place?: string

--- a/src/types/Mode.ts
+++ b/src/types/Mode.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export enum TransportMode {
     AIR = 'air',
     BUS = 'bus',
@@ -12,6 +18,12 @@ export enum TransportMode {
     WATER = 'water',
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export enum TransportSubmode {
     AIRPORT_LINK_BUS = 'airportLinkBus',
     AIRPORT_LINK_RAIL = 'airportLinkRail',
@@ -51,6 +63,12 @@ export enum TransportSubmode {
     TOURIST_RAILWAY = 'touristRailway',
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export enum LegMode {
     AIR = 'air',
     BICYCLE = 'bicycle',
@@ -68,7 +86,10 @@ export enum LegMode {
 }
 
 /**
- * All valid values for the "mode" parameter to JourneyPlanner
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
  */
 export enum QueryMode {
     AIR = 'air',

--- a/src/types/StopPlace.ts
+++ b/src/types/StopPlace.ts
@@ -3,6 +3,12 @@ import { TransportMode, TransportSubmode } from '../types/Mode'
 
 import { Quay } from '../fields/Quay'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface StopPlaceDetails {
     id: string
     name: string
@@ -20,22 +26,52 @@ export interface StopPlaceDetails {
     quays?: Quay[]
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type LimitationStatusType = 'FALSE' | 'TRUE' | 'PARTIAL' | 'UNKNOWN'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type WaitingRoomEquipment = {
     id: string
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type ShelterEquipment = {
     id: string
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type SanitaryEquipment = {
     id: string
     numberOfToilets: number
     gender: 'both' | 'femaleOnly' | 'maleOnly' | 'sameSexOnly'
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type TicketingEquipment = {
     id: string
     ticketOffice: boolean
@@ -43,6 +79,12 @@ export type TicketingEquipment = {
     numberOfMachines: number
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export type ParkingVehicle =
     | 'pedalCycle'
     | 'moped'
@@ -80,6 +122,12 @@ export type ParkingVehicle =
     | 'allPassengerVehicles'
     | 'all'
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface StopPlaceFacilitiesStopPlace {
     id: string
     name: MultilingualString
@@ -97,6 +145,12 @@ export interface StopPlaceFacilitiesStopPlace {
     }
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface StopPlaceFacilitiesParking {
     name: MultilingualString
     parentSiteRef: string
@@ -105,6 +159,12 @@ export interface StopPlaceFacilitiesParking {
     parkingVehicleTypes?: ParkingVehicle[]
 }
 
+/**
+ * @deprecated
+ * The JourneyPlanner v2 queries and types are deprecated.
+ * Write your own GraphQL queries for JourneyPlanner v3.
+ * Write your own types or use those from JourneyPlannerTypes where applicable.
+ */
 export interface StopPlaceFacilities {
     stopPlace: StopPlaceFacilitiesStopPlace[]
     parking: StopPlaceFacilitiesParking[]


### PR DESCRIPTION
The JourneyPlanner v2 API is deprecated and everybody should move over to v3.

We will not migrate the existing SDK methods to the new API version. We want to encourage users to create their own queries, so that they will be able to leverage the full flexibility of GraphQL.

There are powerful GraphQL libraries and frameworks like Apollo. Combined with our generated types JourneyPlannerTypes or your own generated types, you get both the full flexibility of GraphQL and TypeScript coverage.