### PR TITLE
Add pricePlan to mobility graphql query

### DIFF
--- a/src/mobility/getVehicles/query.ts
+++ b/src/mobility/getVehicles/query.ts
@@ -30,6 +30,18 @@ query ($lat: Float!, $lon: Float!, $range: Int!, $count: Int, $operators: [Strin
                     value
                 }
             }
+            perKmPricing {
+                start
+                rate
+                interval
+                end
+            }
+            perMinPricing {
+                start
+                rate
+                interval
+                end
+            }
             price
             surgePricing
             url


### PR DESCRIPTION
Add `perKmPricing` and `perMinPricing` to graphql query for Vehicles.